### PR TITLE
Add support for phasing linked reads

### DIFF
--- a/whatshap/cli/phase.py
+++ b/whatshap/cli/phase.py
@@ -279,6 +279,7 @@ def run_whatshap(
     write_command_line_header=True,
     use_ped_samples=False,
     algorithm="whatshap",
+    linked_reads=False,
 ):
     """
     Run WhatsHap.
@@ -353,6 +354,7 @@ def run_whatshap(
                 ignore_read_groups,
                 mapq_threshold=mapping_quality,
                 indels=indels,
+                linked=linked_reads,
             )
         )
         show_phase_vcfs = phased_input_reader.has_vcfs
@@ -977,6 +979,9 @@ def add_arguments(parser):
     arg("--merge-reads", dest="read_merging", default=False, action="store_true",
         help="Merge reads which are likely to come from the same haplotype "
         "(default: do not merge reads)")
+    arg("--linked-reads", default=False, action="store_true",
+        help="Treat reads that have the same BX tag value as coming from the same molecule. "
+             "Use this to phase data from 10X Chromium or similar technologies.")
     arg("--max-coverage", "-H", metavar="MAXCOV", type=int,
         dest="max_coverage_was_used", help=SUPPRESS)
     arg("--internal-downsampling", metavar="COVERAGE", dest="max_coverage", default=15, type=int,

--- a/whatshap/cli/phase.py
+++ b/whatshap/cli/phase.py
@@ -38,7 +38,7 @@ from whatshap.pedigree import (
 from whatshap.timer import StageTimer
 from whatshap.utils import plural_s
 from whatshap.cli import CommandLineError, log_memory_usage, PhasedInputReader
-from whatshap.merge import ReadMerger, DoNothingReadMerger
+from whatshap.merge import ReadMerger, DoNothingReadMerger, IdenticalReadMerger
 
 __author__ = "Murray Patterson, Alexander Schönhuth, Tobias Marschall, Marcel Martin"
 
@@ -327,12 +327,13 @@ def run_whatshap(
         command_line = None
 
     if read_merging:
-        read_merger = ReadMerger(
-            read_merging_error_rate,
-            read_merging_max_error_rate,
-            read_merging_positive_threshold,
-            read_merging_negative_threshold,
-        )
+        read_merger = IdenticalReadMerger()
+        # read_merger = ReadMerger(
+        #     read_merging_error_rate,
+        #     read_merging_max_error_rate,
+        #     read_merging_positive_threshold,
+        #     read_merging_negative_threshold,
+        # )
     else:
         read_merger = DoNothingReadMerger()
 
@@ -416,7 +417,8 @@ def run_whatshap(
                 logger.info("======== Working on chromosome %r", chromosome)
             else:
                 logger.info(
-                    "Leaving chromosome %r unchanged (present in VCF but not requested by option --chromosome)",
+                    "Leaving chromosome %r unchanged "
+                    "(present in VCF but not requested by option --chromosome)",
                     chromosome,
                 )
                 with timers("write_vcf"):
@@ -451,6 +453,26 @@ def run_whatshap(
                     family, include_homozygous, trios, variant_table
                 )
 
+                def search_for_variant(rs):
+                    return
+                    vc = 0
+                    for read in rs:
+                        for variant in read:
+                            if variant.position == 19862646:
+                                logger.debug(
+                                    f"Found the variant in read {read.name} {read.reference_start}"
+                                )
+                                prev = None
+                                for v in read:
+
+                                    logger.debug(
+                                        f"  {v.position} {v.allele} {v.quality} {v.position - prev if prev is not None else ''}"
+                                    )
+                                    prev = v.position
+                                vc += 1
+                                break
+                    logger.info(f"found variant in {vc} reads")
+
                 # Get the reads belonging to each sample
                 readsets = dict()  # TODO this could become a list
                 for sample in family:
@@ -465,6 +487,8 @@ def run_whatshap(
                         readset = readset.subset(
                             [i for i, read in enumerate(readset) if len(read) >= 2]
                         )
+                        search_for_variant(readset)
+
                         logger.info(
                             "Kept %d reads that cover at least two variants each", len(readset),
                         )
@@ -474,6 +498,7 @@ def run_whatshap(
                             max_coverage_per_sample,
                             preferred_source_ids=vcf_source_ids,
                         )
+                        search_for_variant(selected_reads)
 
                     readsets[sample] = selected_reads
                     if len(family) == 1 and not distrust_genotypes:

--- a/whatshap/variants.py
+++ b/whatshap/variants.py
@@ -108,8 +108,19 @@ class ReadSetReader:
     @staticmethod
     def _make_readset_from_grouped_reads(groups: Iterable[List[Read]]) -> ReadSet:
         read_set = ReadSet()
+        names = set()
         for group in groups:
-            read_set.add(merge_reads(*group))
+            read = merge_reads(*group)
+            if read.name in names:
+                # Two reads can have the same name because linked reads are
+                # only grouped by BX tag value, not by name. That is, both the
+                # left and right read could start a read cloud. Since the name
+                # of the merged read resulting from a read cloud is the name
+                # of its leftmost read, this leads to a collision.
+                # This happens very rarely.
+                continue
+            read_set.add(read)
+            names.add(read.name)
         return read_set
 
     @staticmethod


### PR DESCRIPTION
(Transferred from https://bitbucket.org/whatshap/whatshap/pull-requests/43)

This adds preliminary support for treating read clouds (reads that all have the same BX tag value) as a single read. This allows us to phase data from 10X Chromium and similar technologies.

Use `--linked-reads` to enable.

I just finished this and ran it on my small test dataset, but it needs more testing. Although we’ve previously discussed that physical coverage could be a problem, I don’t see that on this small test dataset. In any case, the results are definitely better than when not using `--linked-reads`.

@tobiasmarschall commented:
> When we tried this years ago (see branch 10xG_phasing), the results weren’t horrible, but worse than LongRanger, particularly in terms of switch errors.