### PR TITLE
Allow colon in region specifications

### DIFF
--- a/tests/test_run_haplotag.py
+++ b/tests/test_run_haplotag.py
@@ -3,7 +3,7 @@ import shutil
 import pysam
 import pytest
 
-from whatshap.cli.haplotag import run_haplotag
+from whatshap.cli.haplotag import run_haplotag, Region, InvalidRegion
 from whatshap.cli import CommandLineError
 
 
@@ -384,28 +384,13 @@ def test_haplotag_nonexisting_region():
         )
 
 
-def test_haplotag_malformed_region_interval():
-    # Region 2 has a start larger than the end
-    with pytest.raises(ValueError):
-        run_haplotag(
-            variant_file="tests/data/haplotag_1.vcf.gz",
-            alignment_file="tests/data/haplotag.bam",
-            haplotag_list=None,
-            output=None,
-            regions=["chr1:0-100", "chr1:500-200"],
-        )
-
-
-def test_haplotag_malformed_input_format():
-    # Region 2 uses colon twice as separator
-    with pytest.raises(ValueError):
-        run_haplotag(
-            variant_file="tests/data/haplotag_1.vcf.gz",
-            alignment_file="tests/data/haplotag.bam",
-            haplotag_list=None,
-            output=None,
-            regions=["chr1:0", "chr1:200:500"],
-        )
+def test_haplotag_region_start_greater_than_end():
+    with pytest.raises(InvalidRegion):
+        Region.parse("chr1:500-200")
+    with pytest.raises(InvalidRegion):
+        Region.parse("chr1:500-200:17")
+    with pytest.raises(InvalidRegion):
+        Region.parse("chr1:a-b")
 
 
 def test_haplotag_selected_regions(tmp_path):

--- a/whatshap/cli/haplotag.py
+++ b/whatshap/cli/haplotag.py
@@ -265,6 +265,10 @@ def normalize_user_regions(user_regions, bam_references):
     return norm_regions
 
 
+class InvalidRegion(Exception):
+    pass
+
+
 @dataclass
 class Region:
     chromosome: str
@@ -303,8 +307,10 @@ class Region:
                     end = None
                 else:
                     end = int(start_end[1])
+                    if end <= start:
+                        raise InvalidRegion("end is before start in specified region")
             except ValueError:
-                raise ValueError("Region must be specified as chrom[:start[-end]])") from None
+                raise InvalidRegion("Region must be specified as chrom[:start[-end]])") from None
         return Region(chromosome, start, end)
 
 

--- a/whatshap/cli/haplotag.py
+++ b/whatshap/cli/haplotag.py
@@ -287,6 +287,8 @@ class Region:
         Region("chr1", 100, None)
         >>> Region.parse("chr1:101-200")
         Region("chr1", 100, 200)
+        >>> Region.parse("chr1:101:200")  # for backwards compatibility
+        Region("chr1", 100, 200)
         """
         parts = spec.split(":", maxsplit=1)
         chromosome = parts[0]
@@ -294,7 +296,8 @@ class Region:
             start, end = 0, None
         else:
             try:
-                start_end = parts[1].split("-", maxsplit=1)
+                sep = ":" if ":" in parts[1] else "-"
+                start_end = parts[1].split(sep, maxsplit=1)
                 start = int(start_end[0]) - 1
                 if len(start_end) == 1 or not start_end[1]:
                     end = None


### PR DESCRIPTION
For backwards compatibility, we need to allow `chr:start:end` in addition to `chr:start-end` when specifying a `--region` for `whatshap haplotag`.

I have also simplified the tests a bit. It’s not necessary to run the full `run_haplotag` function just to see whether an invalid region is correctly caught, we should instead test the parsing code directly.

See #262