### PR TITLE
Parallel polyphase

### DIFF
--- a/src/polyphase/readscoring.cpp
+++ b/src/polyphase/readscoring.cpp
@@ -106,7 +106,7 @@ void ReadScoring::scoreReadsetLocal(TriangleSparseMatrix* result, ReadSet* reads
             windowStartPosition = posList[current];
         }
     }
-    windowStarts.push_back(posList.size()+1);
+    windowStarts.push_back(posList.size());
     
     // determine relative hamming distance for same and different haplotypes for each window
     for (uint32_t windowIdx = 0; windowIdx < windowStarts.size()-1; windowIdx++) {

--- a/whatshap/cli/__init__.py
+++ b/whatshap/cli/__init__.py
@@ -188,9 +188,9 @@ class PhasedInputReader:
         return readset, vcf_source_ids
 
 
-def log_memory_usage(multiprocessing=False):
+def log_memory_usage(include_children=False):
     if sys.platform == "linux":
-        if multiprocessing:
+        if include_children:
             memory_kb = (
                 resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
                 + resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss

--- a/whatshap/cli/__init__.py
+++ b/whatshap/cli/__init__.py
@@ -188,7 +188,13 @@ class PhasedInputReader:
         return readset, vcf_source_ids
 
 
-def log_memory_usage():
+def log_memory_usage(multiprocessing=False):
     if sys.platform == "linux":
-        memory_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if multiprocessing:
+            memory_kb = (
+                resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+                + resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+            )
+        else:
+            memory_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
         logger.info("Maximum memory usage: %.3f GB", memory_kb / 1e6)

--- a/whatshap/cli/polyphase.py
+++ b/whatshap/cli/polyphase.py
@@ -450,7 +450,9 @@ def phase_single_individual(readset, phasable_variant_table, sample, phasing_par
         blockwise_cut_positions,
         blockwise_haploid_cuts,
     ) = ([], [], [], [], [])
-    processed_non_singleton_blocks = 0
+
+    # Create genotype slices for blocks
+    genotype_slices = []
     for block_id, block_readset in enumerate(block_readsets):
         block_start = ext_block_starts[block_id]
         block_end = ext_block_starts[block_id + 1]
@@ -477,15 +479,15 @@ def phase_single_individual(readset, phasable_variant_table, sample, phasing_par
                     )
                 )
 
-	    clustering, path, haplotypes, cut_positions, haploid_cuts = phase_single_block(
-	        block_readset, genotype_slices[block_id], phasing_param, timers
-	    )
+            clustering, path, haplotypes, cut_positions, haploid_cuts = phase_single_block(
+                block_readset, genotype_slices[block_id], phasing_param, timers
+            )
 
-	    blockwise_clustering.append(clustering)
-	    blockwise_paths.append(path)
-	    blockwise_haplotypes.append(haplotypes)
-	    blockwise_cut_positions.append(cut_positions)
-	    blockwise_haploid_cuts.append(haploid_cuts)
+            blockwise_clustering.append(clustering)
+            blockwise_paths.append(path)
+            blockwise_haplotypes.append(haplotypes)
+            blockwise_cut_positions.append(cut_positions)
+            blockwise_haploid_cuts.append(haploid_cuts)
 
     else:
         # sort block readsets in descending order by number of reads
@@ -528,7 +530,14 @@ def phase_single_individual(readset, phasable_variant_table, sample, phasing_par
             blockwise_results.sort(key=lambda x: x[-1])
 
             # collect all blockwise results
-            for (clustering, path, haplotypes, cut_positions, haploid_cuts, block_id) in blockwise_results:
+            for (
+                clustering,
+                path,
+                haplotypes,
+                cut_positions,
+                haploid_cuts,
+                block_id,
+            ) in blockwise_results:
                 blockwise_clustering.append(clustering)
                 blockwise_paths.append(path)
                 blockwise_haplotypes.append(haplotypes)
@@ -803,7 +812,7 @@ def phase_single_block_mt(
     del block_readset
     if block_vars > 1:
         logger.info("Finished block {}.".format(job_id + 1))
-    return clustering, path, haplotypes, cut_positions, block_id
+    return clustering, path, haplotypes, cut_positions, haploid_cuts, block_id
 
 
 def aggregate_phasing_blocks(

--- a/whatshap/cli/polyphase.py
+++ b/whatshap/cli/polyphase.py
@@ -358,7 +358,7 @@ def run_polyphase(
 
     logger.info("\n== SUMMARY ==")
 
-    log_memory_usage(multiprocessing=(threads > 1))
+    log_memory_usage(include_children=(threads > 1))
     logger.info(
         "Time spent reading BAM/CRAM:                 %6.1f s", timers.elapsed("read_bam"),
     )

--- a/whatshap/cli/polyphase.py
+++ b/whatshap/cli/polyphase.py
@@ -358,7 +358,7 @@ def run_polyphase(
 
     logger.info("\n== SUMMARY ==")
 
-    log_memory_usage()
+    log_memory_usage(multiprocessing=(threads > 1))
     logger.info(
         "Time spent reading BAM/CRAM:                 %6.1f s", timers.elapsed("read_bam"),
     )
@@ -992,12 +992,13 @@ def compute_linkage_based_block_starts(readset, pos_index, ploidy, single_linkag
             continue
         q = Queue()
         q.put(i)
+        merged_clust[i] = new_num_clust
         while not q.empty():
             cur = q.get()
-            merged_clust[cur] = new_num_clust
             for linked in link_coverage[cur]:
                 if merged_clust[linked] < 0 and link_coverage[cur][linked] >= cut_threshold:
                     q.put(linked)
+                    merged_clust[linked] = new_num_clust
         new_num_clust += 1
 
     # determine cut positions

--- a/whatshap/polyphaseplots.py
+++ b/whatshap/polyphaseplots.py
@@ -11,14 +11,55 @@ from whatshap.cli.compare import compute_switch_flips_poly_bt
 This class is exclusively used for debugging and development.
 """
 
+logger = logging.getLogger(__name__)
+
+
+def draw_plots(
+    block_readsets,
+    clustering,
+    threading,
+    haplotypes,
+    cut_positions,
+    genotype_list_multi,
+    phasable_variant_table,
+    plot_clusters,
+    plot_threading,
+    output,
+):
+    # Plot options
+    logger.info("Generating plots ...")
+    combined_readset = ReadSet()
+    for block_readset in block_readsets:
+        for read in block_readset:
+            combined_readset.add(read)
+    if plot_clusters:
+        draw_clustering(
+            combined_readset,
+            clustering,
+            phasable_variant_table,
+            output + ".clusters.pdf",
+            genome_space=False,
+        )
+    if plot_threading:
+        index, rev_index = get_position_map(combined_readset)
+        coverage = get_coverage(combined_readset, clustering, index)
+        draw_threading(
+            combined_readset,
+            clustering,
+            coverage,
+            threading,
+            cut_positions,
+            haplotypes,
+            phasable_variant_table,
+            genotype_list_multi,
+            output + ".threading.pdf",
+        )
+
 
 """
 This method only works for a test dataset, for which the true haplotype of read was encoded
 into its name. For any other read name, it just returns -1 for unknown haplotype
 """
-
-
-logger = logging.getLogger(__name__)
 
 
 def parse_haplotype(name):
@@ -32,6 +73,10 @@ def parse_haplotype(name):
             return 2
         elif tokens[-2] == "NA19240" and tokens[-1] == "HAP2":
             return 3
+        elif tokens[-2] == "HG00733" and tokens[-1] == "HAP1":
+            return 4
+        elif tokens[-2] == "HG00733" and tokens[-1] == "HAP2":
+            return 5
     except:
         pass
     return -1

--- a/whatshap/polyphaseplots.py
+++ b/whatshap/polyphaseplots.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 import logging
 from whatshap.core import Read, ReadSet
 from whatshap.cli.compare import compute_switch_flips_poly_bt
+from whatshap.threading import get_position_map, get_coverage
 
 """
 This class is exclusively used for debugging and development.


### PR DESCRIPTION
This pull request contains a parallelization for the polyphase module. The algorithms themselves are not changed, but the phasing is parallelized on a block-level. This means that it can only achieve a speed-up, if there are actually some weekly (or un-)connected components in the readset. The implementation uses the `multiprocessing` library of Python, which forks the main process. A thread-level parallelization is technically not possible with Python due the Global Interpreter Lock.

The parallelization must be requested via the `--threads` parameter when executing the module. The default is 1 thread, which invokes no fork at all. Running multiple threads increases the memory consumption (see example below), because the worker threads create local data structures, which are needed for the phasing. The main readset is not duplicated per thread.

Note, that only the phasing stage is parallelized. The pre- and postprocessing (splitting blocks, writing VCF) and the I/O at the beginning are not. Therefore the overall speed-up is not too impressing, but still better than nothing. I ran one of the tetraploid-human samples from the polyphase publication (full chr1, 40X, default `whatshap polyphase` settings) with 1 thread and with 8 threads on an 8-core CPU. The running times look like this:

```
== SUMMARY ==
Maximum memory usage: 1.178 GB
Time spent reading BAM/CRAM:                  473.8 s
Time spent parsing VCF:                         4.6 s
Time spent detecting blocks:                   15.0 s
Time spent scoring reads:                      12.3 s
Time spent solving cluster editing:           286.2 s
Time spent threading haplotypes:              101.5 s
Time spent writing VCF:                         5.6 s
Time spent on rest:                             9.6 s
Total elapsed time:                           908.5 s

== SUMMARY ==
Maximum memory usage: 1.130 GB (actually about 2.75GB, manual readout with htop)
Time spent reading BAM/CRAM:                  468.5 s
Time spent parsing VCF:                         4.4 s
Time spent detecting blocks:                   15.3 s
Time spent phasing blocks:                     63.2 s
Time spent writing VCF:                         5.5 s
Time spent on rest:                             9.6 s
Total elapsed time:                           566.6 s

```

The phasing time is reduced from about 400s to 63s, which is a speed-up of ~6,4. In multithreading mode, the individual steps (scoring, cluster editing, threading) are not timed anymore, because this would require to collect timer data over all processes. I did not look into this for now, therefore there is just a total phasing time at the moment. The memory consumption is also hard to read. The current method only measures the main process, but not all child processes. I am not sure, how to solve this problem at the moment. Obviously, the memory consumption is far less than [main process consumption] times [number of threads], as the manual readout from htop shows.

I compared several phasings, both done with single und multi threading and I always got equal results, i.e. `whatshap compare` did not find a single switch or flip error between the output VCFs.

One technical note: Forking processes requires all shared objects to be (de-)serializable. I implemented a `__getstate__` and `__setstate__` method for Read and ReadSet, as suggested by the pickle documentation: https://docs.python.org/3.6/library/pickle.html#pickling-class-instances

Any thoughts about this?