### PR TITLE
Move Region dataclass

### DIFF
--- a/tests/test_run_haplotag.py
+++ b/tests/test_run_haplotag.py
@@ -3,7 +3,7 @@ import shutil
 import pysam
 import pytest
 
-from whatshap.cli.haplotag import run_haplotag, Region, InvalidRegion
+from whatshap.cli.haplotag import run_haplotag
 from whatshap.cli import CommandLineError
 
 
@@ -382,15 +382,6 @@ def test_haplotag_nonexisting_region():
             output=None,
             regions=["chr2"],
         )
-
-
-def test_haplotag_region_start_greater_than_end():
-    with pytest.raises(InvalidRegion):
-        Region.parse("chr1:500-200")
-    with pytest.raises(InvalidRegion):
-        Region.parse("chr1:500-200:17")
-    with pytest.raises(InvalidRegion):
-        Region.parse("chr1:a-b")
 
 
 def test_haplotag_selected_regions(tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ from whatshap.utils import (
     IndexedFasta,
     FastaNotIndexedError,
     Region,
-    InvalidRegion
+    InvalidRegion,
 )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,13 @@
 import os.path
 
 from pytest import raises
-from whatshap.utils import detect_file_format, IndexedFasta, FastaNotIndexedError
+from whatshap.utils import (
+    detect_file_format,
+    IndexedFasta,
+    FastaNotIndexedError,
+    Region,
+    InvalidRegion
+)
 
 
 def test_detect_alignment_file_format():
@@ -19,3 +25,12 @@ def test_missing_fai():
     assert not os.path.exists("tests/data/not-indexed.fasta.fai")
     with raises(FastaNotIndexedError):
         IndexedFasta("tests/data/not-indexed.fasta")
+
+
+def test_region_start_greater_than_end():
+    with raises(InvalidRegion):
+        Region.parse("chr1:500-200")
+    with raises(InvalidRegion):
+        Region.parse("chr1:500-200:17")
+    with raises(InvalidRegion):
+        Region.parse("chr1:a-b")

--- a/whatshap/cli/haplotag.py
+++ b/whatshap/cli/haplotag.py
@@ -11,7 +11,6 @@ import pysam
 import hashlib
 from collections import defaultdict
 from typing import List
-from dataclasses import dataclass
 
 from xopen import xopen
 

--- a/whatshap/cli/haplotag.py
+++ b/whatshap/cli/haplotag.py
@@ -21,6 +21,7 @@ from whatshap.cli import PhasedInputReader, CommandLineError
 from whatshap.vcf import VcfReader, VcfError, VariantTable, VariantCallPhase
 from whatshap.core import NumericSampleIds
 from whatshap.timer import StageTimer
+from whatshap.utils import Region
 
 
 logger = logging.getLogger(__name__)
@@ -263,55 +264,6 @@ def normalize_user_regions(user_regions, bam_references):
                 )
             norm_regions[region.chromosome].append((region.start, region.end))
     return norm_regions
-
-
-class InvalidRegion(Exception):
-    pass
-
-
-@dataclass
-class Region:
-    chromosome: str
-    start: int
-    end: int
-
-    def __repr__(self):
-        return f'Region("{self.chromosome}", {self.start}, {self.end})'
-
-    @staticmethod
-    def parse(spec: str):
-        """
-        >>> Region.parse("chr1")
-        Region("chr1", 0, None)
-        >>> Region.parse("chr1:")
-        Region("chr1", 0, None)
-        >>> Region.parse("chr1:101")
-        Region("chr1", 100, None)
-        >>> Region.parse("chr1:101-")
-        Region("chr1", 100, None)
-        >>> Region.parse("chr1:101-200")
-        Region("chr1", 100, 200)
-        >>> Region.parse("chr1:101:200")  # for backwards compatibility
-        Region("chr1", 100, 200)
-        """
-        parts = spec.split(":", maxsplit=1)
-        chromosome = parts[0]
-        if len(parts) == 1 or not parts[1]:
-            start, end = 0, None
-        else:
-            try:
-                sep = ":" if ":" in parts[1] else "-"
-                start_end = parts[1].split(sep, maxsplit=1)
-                start = int(start_end[0]) - 1
-                if len(start_end) == 1 or not start_end[1]:
-                    end = None
-                else:
-                    end = int(start_end[1])
-                    if end <= start:
-                        raise InvalidRegion("end is before start in specified region")
-            except ValueError:
-                raise InvalidRegion("Region must be specified as chrom[:start[-end]])") from None
-        return Region(chromosome, start, end)
 
 
 def compute_variant_file_samples_to_use(vcf_samples, user_given_samples, ignore_read_groups):

--- a/whatshap/utils.py
+++ b/whatshap/utils.py
@@ -1,8 +1,13 @@
 import gzip
 import pyfaidx
+from dataclasses import dataclass
 
 
 class FastaNotIndexedError(Exception):
+    pass
+
+
+class InvalidRegion(Exception):
     pass
 
 
@@ -42,3 +47,48 @@ def IndexedFasta(path):
 
 def plural_s(n: int) -> str:
     return "" if n == 1 else "s"
+
+
+@dataclass
+class Region:
+    chromosome: str
+    start: int
+    end: int
+
+    def __repr__(self):
+        return f'Region("{self.chromosome}", {self.start}, {self.end})'
+
+    @staticmethod
+    def parse(spec: str):
+        """
+        >>> Region.parse("chr1")
+        Region("chr1", 0, None)
+        >>> Region.parse("chr1:")
+        Region("chr1", 0, None)
+        >>> Region.parse("chr1:101")
+        Region("chr1", 100, None)
+        >>> Region.parse("chr1:101-")
+        Region("chr1", 100, None)
+        >>> Region.parse("chr1:101-200")
+        Region("chr1", 100, 200)
+        >>> Region.parse("chr1:101:200")  # for backwards compatibility
+        Region("chr1", 100, 200)
+        """
+        parts = spec.split(":", maxsplit=1)
+        chromosome = parts[0]
+        if len(parts) == 1 or not parts[1]:
+            start, end = 0, None
+        else:
+            try:
+                sep = ":" if ":" in parts[1] else "-"
+                start_end = parts[1].split(sep, maxsplit=1)
+                start = int(start_end[0]) - 1
+                if len(start_end) == 1 or not start_end[1]:
+                    end = None
+                else:
+                    end = int(start_end[1])
+                    if end <= start:
+                        raise InvalidRegion("end is before start in specified region")
+            except ValueError:
+                raise InvalidRegion("Region must be specified as chrom[:start[-end]])") from None
+        return Region(chromosome, start, end)


### PR DESCRIPTION
- moves Region dataclass from haplotag to utils
- moves Region dataclass specific test to utils test module
- prepare using more fine-grained region definitions in other cli modules besides haplotag (e.g. suggested for #270)