### PR TITLE
Remove --full-genotyping option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ development version
 * :issue:`251`: Allow ``haplotag`` to correctly write to standard output.
 * :issue:`207`: Allow multiple ``--chromosome`` arguments to ``stats``.
 * The file created with ``--output-read-list`` was not correctly tab-separated.
+* :issue:`248`: Remove ``phase --full-genotyping`` option. Instead, use ``whatshap genotype``
+  followed by ``whatshap phase``.
 * :pr:`265`: ``polyphase`` can now work in parallel
 
 v1.0 (2020-06-24)

--- a/tests/test_run_phase.py
+++ b/tests/test_run_phase.py
@@ -944,16 +944,6 @@ def test_indel_phasing(algorithm, tmp_path):
     assert_phasing(table.phases_of("sample1"), [phase0, phase1, phase0, phase1])
 
 
-def test_full_genotyping(algorithm):
-    run_whatshap(
-        phase_input_files=["tests/data/oneread.bam"],
-        variant_file="tests/data/onevariant.vcf",
-        output="/dev/null",
-        full_genotyping=True,
-        algorithm=algorithm,
-    )
-
-
 def test_with_read_merging(algorithm):
     run_whatshap(
         phase_input_files=["tests/data/pacbio/pacbio.bam"],


### PR DESCRIPTION
This removes `--full-genotyping` from `whatshap phase`.

What about `--distrust-genotypes`, should that also be removed? Then I’ll add that to this PR.

Closes #248