### PR TITLE
Add missing C++ header

### DIFF
--- a/src/polyphase/trianglesparsematrix.h
+++ b/src/polyphase/trianglesparsematrix.h
@@ -1,6 +1,7 @@
 #ifndef TRIANGLESPARSEMATRIX_H
 #define TRIANGLESPARSEMATRIX_H
 
+#include <cstdint>
 #include <unordered_map>
 #include <set>
 #include <vector>


### PR DESCRIPTION
Recent g++ requires this include (it is not included by the other anymore)