### PR TITLE
Add option --ignore-sample-name to compare.py 

### DIFF
--- a/tests/data/phased_single_sample1.vcf
+++ b/tests/data/phased_single_sample1.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.1
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1
+chrA	100	.	A	T	500.0	.	.	GT:PS	0|1:150
+chrA	150	.	C	GGGG	500.0	.	.	GT:PS	1|0:150
+chrA	300	.	G	T	500.0	.	.	GT:PS	1|0:150
+chrA	350	.	GAG	T	500.0	.	.	GT:PS	1|0:150
+chrA	500	.	C	T	500.0	.	.	GT:PS	1|0:150

--- a/tests/data/phased_single_sample2.vcf
+++ b/tests/data/phased_single_sample2.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.1
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	nr1
+chrA	100	.	A	T	500.0	.	.	GT:PS	0|1:100
+chrA	150	.	C	GGGG	500.0	.	.	GT:PS	0|1:100
+chrA	300	.	G	T	500.0	.	.	GT:PS	0|1:150
+chrA	350	.	GAG	T	500.0	.	.	GT:PS	0|1:150
+chrA	500	.	C	T	500.0	.	.	GT:PS	1|0:150

--- a/tests/test_run_compare.py
+++ b/tests/test_run_compare.py
@@ -322,3 +322,29 @@ def test_compare_block():
     assert phasing_errors.hamming == 2.0
     switch_flips = phasing_errors.switch_flips
     assert switch_flips.switches == 0.0
+
+
+def test_compare_ignore_sample_name(tmp_path):
+    outtsv = tmp_path / "output.tsv"
+    run_compare(
+        vcf=["tests/data/phased_single_sample1.vcf", "tests/data/phased_single_sample2.vcf"],
+        ploidy=2,
+        names="p1,p2",
+        tsv_pairwise=outtsv,
+        sample=None,
+        ignore_sample_name=True,
+    )
+    lines = [l.split("\t") for l in open(outtsv)]
+    assert len(lines) == 2
+    Fields = namedtuple("Fields", [f.strip("#\n") for f in lines[0]])
+    entry = Fields(*lines[1])
+
+    assert entry.chromosome == "chrA"
+    assert entry.sample == "sample1_nr1"
+    assert entry.all_assessed_pairs == "3"
+    assert entry.all_switches == "2"
+    assert entry.all_switchflips == "2/0"
+    assert entry.blockwise_hamming == "2"
+    assert entry.largestblock_assessed_pairs == "2"
+    assert entry.largestblock_switches == "1"
+    assert entry.largestblock_hamming == "1"

--- a/whatshap/cli/compare.py
+++ b/whatshap/cli/compare.py
@@ -1035,8 +1035,8 @@ def get_sample_names(
 
         if ignore_name and len(vcf_reader.samples) > 1:
             raise CommandLineError(
-                "File {!r} contains multiple samples, option --ignore-sample-name not available.".format(
-                    vcf_reader.path
+                "File '{file}' contains multiple samples, option --ignore-sample-name not available.".format(
+                    file=vcf_reader.path
                 )
             )
         first_samples.append(vcf_reader.samples[0])


### PR DESCRIPTION
Fix #334.

To make this work I had to change sample name handling to use a list contain the sample name for each input file.  