### PR TITLE
Fix --merge-reads option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,15 @@
 Changes
 =======
 
+development version
+-------------------
+
+* :issue:`208`: Fix ``phase --merge-reads``. This option has never worked correctly and just led to
+  ``whatshap phase`` taking a very long time and in some cases even crashing. With the fix, the
+  option should work as intended, but we have not evaluated how much it improves phasing results.
+* :issue:`337`: Add ``--skip-missing-contigs`` option to ``whatshap haplotag``
+* :pr:`335`: Add option ``--ignore-sample-name`` to ``whatshap compare`` (thanks to Pontus Höjer)
+
 v1.1 (2021-04-08)
 -----------------
 

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -149,12 +149,10 @@ class ReadMerger(ReadMergerBase):
                 blue_component[v] = current_component
             current_component += 1
 
-        # Keep only the notblue edges that are inside a blue connected component
-        good_notblue_edges = [
-            (v, w) for (v, w) in gnotblue.edges() if blue_component[v] == blue_component[w]
-        ]
-
-        for (u, v) in good_notblue_edges:
+        for (u, v) in gnotblue.edges():
+            if blue_component[u] != blue_component[v]:
+                # Keep only the notblue edges that are inside a blue connected component
+                continue
             while v in nx.node_connected_component(gblue, u):
                 path = nx.shortest_path(gblue, source=u, target=v)
                 # Remove the edge with the smallest support

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -81,7 +81,7 @@ class ReadMerger(ReadMergerBase):
         reads = []
         queue = {}
         for i, read in enumerate(readset):
-            snps = []
+            alleles = []
             orgn = []
             for variant in read:
                 position = variant.position
@@ -90,15 +90,14 @@ class ReadMerger(ReadMergerBase):
 
                 orgn.append((position, allele, quality))
                 assert allele in (0, 1)
-                snps.append(allele)
-
+                alleles.append(allele)
             reads.append(orgn)
 
             begin = read[0].position
-            end = begin + len(snps)
+            end = begin + len(alleles)
             gblue.add_node(i, begin=begin, end=end)
             gnotblue.add_node(i, begin=begin, end=end)
-            queue[i] = {"begin": begin, "end": end, "sites": snps}
+            queue[i] = {"begin": begin, "end": end, "alleles": alleles}
             for x in [id for id in queue.keys() if queue[id]["end"] <= begin]:  # type: ignore
                 del queue[x]
             for j in queue.keys():
@@ -217,7 +216,7 @@ def eval_overlap(n1, n2):
     mismatches) between a pair (n1,n2) of overlapping reads
     """
     hang1 = n2["begin"] - n1["begin"]
-    overlap = zip(n1["sites"][hang1:], n2["sites"])
+    overlap = zip(n1["alleles"][hang1:], n2["alleles"])
     match = mismatch = 0
     for (c1, c2) in overlap:
         if c1 == c2:

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -63,9 +63,7 @@ class ReadMerger(ReadMergerBase):
         )
         logger.debug("Merging started.")
         gblue = Graph()
-        gred = Graph()
         gnotblue = Graph()
-        gnotred = Graph()
 
         # Probability that any nucleotide is wrong
         error_rate = self._error_rate
@@ -116,8 +114,6 @@ class ReadMerger(ReadMergerBase):
 
             gblue.add_node(id, begin=begin, end=end, sites="".join(snps))
             gnotblue.add_node(id, begin=begin, end=end, sites="".join(snps))
-            gred.add_node(id, begin=begin, end=end, sites="".join(snps))
-            gnotred.add_node(id, begin=begin, end=end, sites="".join(snps))
             queue[id] = {"begin": begin, "end": end, "sites": snps}
             reads[id] = {"begin": begin, "end": end, "sites": snps}
             for x in [id for id in queue.keys() if queue[id]["end"] <= begin]:  # type: ignore
@@ -132,10 +128,6 @@ class ReadMerger(ReadMergerBase):
                     and match - mismatch >= thr_diff
                 ):
                     gblue.add_edge(id1, id, match=match, mismatch=mismatch)
-                    if mismatch - match >= thr_diff:
-                        gred.add_edge(id1, id, match=match, mismatch=mismatch)
-                    if match - mismatch >= thr_neg_diff:
-                        gnotred.add_edge(id1, id, match=match, mismatch=mismatch)
                     if mismatch - match >= thr_neg_diff:
                         gnotblue.add_edge(id1, id, match=match, mismatch=mismatch)
 
@@ -154,20 +146,6 @@ class ReadMerger(ReadMergerBase):
             number_of_nodes(gnotblue),
             number_of_edges(gnotblue),
             len(list(connected_components(gnotblue))),
-        )
-        logger.debug("Red Graph")
-        logger.debug(
-            "Nodes: %s - Edges: %s - ConnComp: %s",
-            number_of_nodes(gred),
-            number_of_edges(gred),
-            len(list(connected_components(gred))),
-        )
-        logger.debug("Non-Red Graph")
-        logger.debug(
-            "Nodes: %s - Edges: %s - ConnComp: %s",
-            number_of_nodes(gnotred),
-            number_of_edges(gnotred),
-            len(list(connected_components(gnotred))),
         )
 
         # We consider the notblue edges as an evidence that two reads

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -92,10 +92,8 @@ class ReadMerger(ReadMergerBase):
                 qual = variant.quality
 
                 orgn.append((site, zyg, qual))
-                if zyg == 0:
-                    snps.append("G")
-                else:
-                    snps.append("C")
+                assert zyg in (0, 1)
+                snps.append(zyg)
 
             begin = read[0].position
             end = begin + len(snps)
@@ -228,11 +226,10 @@ def eval_overlap(n1, n2):
     """
     hang1 = n2["begin"] - n1["begin"]
     overlap = zip(n1["sites"][hang1:], n2["sites"])
-    match, mismatch = (0, 0)
+    match = mismatch = 0
     for (c1, c2) in overlap:
-        if c1 in ["A", "C", "G", "T"] and c2 in ["A", "C", "G", "T"]:
-            if c1 == c2:
-                match += 1
-            else:
-                mismatch += 1
-    return (match, mismatch)
+        if c1 == c2:
+            match += 1
+        else:
+            mismatch += 1
+    return match, mismatch

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -18,7 +18,9 @@ class ReadMergerBase(ABC):
 
 
 class ReadMerger(ReadMergerBase):
-    def __init__(self, error_rate: float, max_error_rate: float, positive_threshold, negative_threshold):
+    def __init__(
+        self, error_rate: float, max_error_rate: float, positive_threshold, negative_threshold
+    ):
         """
         error_rate: the probability that a nucleotide is wrong
         max_error_rate: the maximum error rate of any edge of the read
@@ -180,22 +182,22 @@ class ReadMerger(ReadMergerBase):
                         superreads[r][position] = [0, 0]
                     superreads[r][position][allele] += quality
 
-            merged_reads = ReadSet()
-            readn = 0
-            for id in range(len(reads)):
-                read = Read(f"read{readn}")
-                readn += 1
-                if id in representative:
-                    if id == representative[id]:
-                        for position in sorted(superreads[id]):
-                            z = superreads[id][position]
-                            allele = 0 if z[0] >= z[1] else 1
-                            read.add_variant(position, allele, abs(z[1] - z[0]))
-                        merged_reads.add(read)
-                else:
-                    for position, allele, quality in reads[id]:
-                        read.add_variant(position, allele, quality)
+        merged_reads = ReadSet()
+        readn = 0
+        for id in range(len(reads)):
+            read = Read(f"read{readn}")
+            readn += 1
+            if id in representative:
+                if id == representative[id]:
+                    for position in sorted(superreads[id]):
+                        z = superreads[id][position]
+                        allele = 0 if z[0] >= z[1] else 1
+                        read.add_variant(position, allele, abs(z[1] - z[0]))
                     merged_reads.add(read)
+            else:
+                for position, allele, quality in reads[id]:
+                    read.add_variant(position, allele, quality)
+                merged_reads.add(read)
 
         logger.debug("Finished merging reads.")
         logger.info(

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -25,6 +25,16 @@ class ReadMergerBase(ABC):
 
 class ReadMerger(ReadMergerBase):
     def __init__(self, error_rate, max_error_rate, positive_threshold, negative_threshold):
+        """
+        error_rate: the probability that a nucleotide is wrong
+        max_error_rate: the maximum error rate of any edge of the read
+            merging graph allowed before we discard it
+        positive_threshold: The threshold of the ratio between the probabilities
+            that a pair of reads come from the same haplotype and different
+            haplotypes
+        negative_threshold: The threshold of the ratio between the probabilities
+            that a pair of reads come from the same haplotype and different haplotypes.
+        """
         self._error_rate = error_rate
         self._max_error_rate = max_error_rate
         self._positive_threshold = positive_threshold
@@ -38,19 +48,6 @@ class ReadMerger(ReadMergerBase):
         together on one haplotype and on opposite haplotypes.
 
         readset -- the input .core.ReadSet object
-
-        error_rate -- the probability that a nucleotide is wrong
-
-        max_error_rate -- the maximum error rate of any edge of the read
-        merging graph allowed before we discard it
-
-        threshold -- the threshold of the ratio between the probabilities
-        that a pair of reads come from the same haplotype and different
-        haplotypes
-
-        neg_threshold -- The threshold of the ratio between the
-        probabilities that a pair of reads come from the same haplotype
-        and different haplotypes.
         """
         logger.info(
             "Merging %d reads with error rate %.2f, maximum error rate %.2f, "

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -79,11 +79,10 @@ class ReadMerger(ReadMergerBase):
 
         logger.debug("Start reading the reads...")
         id = 0
-        orig_reads = {}
+        orig_reads = []
         queue = {}
         reads = {}
         for read in readset:
-            id += 1
             snps = []
             orgn = []
             for variant in read:
@@ -97,7 +96,7 @@ class ReadMerger(ReadMergerBase):
 
             begin = read[0].position
             end = begin + len(snps)
-            orig_reads[id] = orgn
+            orig_reads.append(orgn)
 
             gblue.add_node(id, begin=begin, end=end)
             gnotblue.add_node(id, begin=begin, end=end)
@@ -117,6 +116,7 @@ class ReadMerger(ReadMergerBase):
                     gblue.add_edge(id1, id, match=match, mismatch=mismatch)
                     if mismatch - match >= thr_neg_diff:
                         gnotblue.add_edge(id1, id, match=match, mismatch=mismatch)
+            id += 1
 
         logger.debug("Finished reading the reads.")
         logger.debug("Number of reads: %s", id)
@@ -176,7 +176,7 @@ class ReadMerger(ReadMergerBase):
                 for id in cc:
                     representative[id] = r
 
-        for id in orig_reads:
+        for id in range(len(orig_reads)):
             if id in representative:
                 for site, zyg, qual in orig_reads[id]:
                     r = representative[id]
@@ -186,8 +186,8 @@ class ReadMerger(ReadMergerBase):
 
             merged_reads = ReadSet()
             readn = 0
-            for id in orig_reads:
-                read = Read("read" + str(readn))
+            for id in range(len(orig_reads)):
+                read = Read(f"read{readn}")
                 readn += 1
                 if id in representative:
                     if id == representative[id]:

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -18,7 +18,7 @@ class ReadMergerBase(ABC):
 
 
 class ReadMerger(ReadMergerBase):
-    def __init__(self, error_rate, max_error_rate, positive_threshold, negative_threshold):
+    def __init__(self, error_rate: float, max_error_rate: float, positive_threshold, negative_threshold):
         """
         error_rate: the probability that a nucleotide is wrong
         max_error_rate: the maximum error rate of any edge of the read
@@ -84,7 +84,6 @@ class ReadMerger(ReadMergerBase):
         reads = {}
         for read in readset:
             id += 1
-            begin_str = read[0].position
             snps = []
             orgn = []
             for variant in read:
@@ -93,12 +92,12 @@ class ReadMerger(ReadMergerBase):
                 qual = variant.quality
 
                 orgn.append([str(site), str(zyg), str(qual)])
-                if int(zyg) == 0:
+                if zyg == 0:
                     snps.append("G")
                 else:
                     snps.append("C")
 
-            begin = int(begin_str)
+            begin = read[0].position
             end = begin + len(snps)
             orig_reads[id] = orgn
 

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -193,11 +193,8 @@ class ReadMerger(ReadMergerBase):
                     if id == representative[id]:
                         for site in sorted(superreads[id]):
                             z = superreads[id][site]
-                            if z[0] >= z[1]:
-                                read.add_variant(site, 0, z[0] - z[1])
-
-                            elif z[1] > z[0]:
-                                read.add_variant(site, 1, z[1] - z[0])
+                            allele = 0 if z[0] >= z[1] else 1
+                            read.add_variant(site, allele, abs(z[1] - z[0]))
                         merged_reads.add(read)
                 else:
                     for site, zyg, qual in orig_reads[id]:

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -81,7 +81,6 @@ class ReadMerger(ReadMergerBase):
         id = 0
         orig_reads = []
         queue = {}
-        reads = {}
         for read in readset:
             snps = []
             orgn = []
@@ -101,7 +100,6 @@ class ReadMerger(ReadMergerBase):
             gblue.add_node(id, begin=begin, end=end)
             gnotblue.add_node(id, begin=begin, end=end)
             queue[id] = {"begin": begin, "end": end, "sites": snps}
-            reads[id] = {"begin": begin, "end": end, "sites": snps}
             for x in [id for id in queue.keys() if queue[id]["end"] <= begin]:  # type: ignore
                 del queue[x]
             for id1 in queue.keys():

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -91,7 +91,7 @@ class ReadMerger(ReadMergerBase):
                 zyg = variant.allele
                 qual = variant.quality
 
-                orgn.append([str(site), str(zyg), str(qual)])
+                orgn.append((site, zyg, qual))
                 if zyg == 0:
                     snps.append("G")
                 else:
@@ -182,10 +182,7 @@ class ReadMerger(ReadMergerBase):
 
         for id in orig_reads:
             if id in representative:
-                for tok in orig_reads[id]:
-                    site = int(tok[0])
-                    zyg = int(tok[1])
-                    qual = int(tok[2])
+                for site, zyg, qual in orig_reads[id]:
                     r = representative[id]
                     if site not in superreads[r]:
                         superreads[r][site] = [0, 0]
@@ -207,8 +204,8 @@ class ReadMerger(ReadMergerBase):
                                 read.add_variant(site, 1, z[1] - z[0])
                         merged_reads.add(read)
                 else:
-                    for tok in orig_reads[id]:
-                        read.add_variant(int(tok[0]), int(tok[1]), int(tok[2]))
+                    for site, zyg, qual in orig_reads[id]:
+                        read.add_variant(site, zyg, qual)
                     merged_reads.add(read)
 
         logger.debug("Finished merging reads.")

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -171,22 +171,22 @@ class ReadMerger(ReadMergerBase):
         # Merge blue components (somehow)
         logger.debug("Started Merging Reads...")
         superreads: Dict = {}  # superreads given by the clusters (if clustering)
-        rep = {}  # cluster representative of a read in a cluster
+        representative = {}  # cluster representative of a read in a cluster
 
         for cc in nx.connected_components(gblue):
             if len(cc) > 1:
                 r = min(cc)
                 superreads[r] = {}
                 for id in cc:
-                    rep[id] = r
+                    representative[id] = r
 
         for id in orig_reads:
-            if id in rep:
+            if id in representative:
                 for tok in orig_reads[id]:
                     site = int(tok[0])
                     zyg = int(tok[1])
                     qual = int(tok[2])
-                    r = rep[id]
+                    r = representative[id]
                     if site not in superreads[r]:
                         superreads[r][site] = [0, 0]
                     superreads[r][site][zyg] += qual
@@ -196,8 +196,8 @@ class ReadMerger(ReadMergerBase):
             for id in orig_reads:
                 read = Read("read" + str(readn))
                 readn += 1
-                if id in rep:
-                    if id == rep[id]:
+                if id in representative:
+                    if id == representative[id]:
                         for site in sorted(superreads[id]):
                             z = superreads[id][site]
                             if z[0] >= z[1]:

--- a/whatshap/merge.py
+++ b/whatshap/merge.py
@@ -101,8 +101,8 @@ class ReadMerger(ReadMergerBase):
             end = begin + len(snps)
             orig_reads[id] = orgn
 
-            gblue.add_node(id, begin=begin, end=end, sites="".join(snps))
-            gnotblue.add_node(id, begin=begin, end=end, sites="".join(snps))
+            gblue.add_node(id, begin=begin, end=end)
+            gnotblue.add_node(id, begin=begin, end=end)
             queue[id] = {"begin": begin, "end": end, "sites": snps}
             reads[id] = {"begin": begin, "end": end, "sites": snps}
             for x in [id for id in queue.keys() if queue[id]["end"] <= begin]:  # type: ignore


### PR DESCRIPTION
This undoes a copy&paste error by de-denting the last for loop in the `ReadMerger.merge`.

This is done in commit except 2c8b242, all the others are refactoring.

The first commit that added the merge functionality (copied over from hapCHAT) is 6cbbee3, and that one shows that indentation was different than what we have now. (It also makes a lot more sense this way.)

I’m not sure it works the way it is supposed to, yet, but at least it doesn’t crash anymore and doesn’t take an eternity to finish. It’s now quite quick actually (increases runtime by sth. like 10-20%)

Closes #208