### PR TITLE
Fix packaging issues by modernizing cythonizing of extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,19 @@ jobs:
     - name: Run tox ${{ matrix.toxenv }}
       run: tox -e ${{ matrix.toxenv }}
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: python -m pip install build
+    - name: Build temporary sdist and wheel
+      run: python -m build
+
   test:
     timeout-minutes: 15
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=43", "wheel", "setuptools_scm", "cython"]
+requires = ["setuptools>=43", "wheel", "setuptools_scm", "cython~=0.29.20"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm", "cython"]
+requires = ["setuptools>=43", "wheel", "setuptools_scm", "cython"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,9 @@ import sys
 import os
 import os.path
 from setuptools import setup, Extension, find_packages
-from distutils.version import LooseVersion
 from setuptools.command.sdist import sdist
 from setuptools.command.build_ext import build_ext
 from distutils.sysconfig import customize_compiler
-
-MIN_CYTHON_VERSION = "0.29"
 
 
 def no_cythonize(extensions, **_ignore):
@@ -34,28 +31,6 @@ def no_cythonize(extensions, **_ignore):
                 sfile = path + ext
             sources.append(sfile)
         extension.sources[:] = sources
-
-
-def check_cython_version():
-    """exit if Cython not found or out of date"""
-    try:
-        from Cython import __version__ as cyversion
-    except ImportError:
-        sys.stdout.write(
-            "ERROR: Cython is not installed. Install at least Cython version "
-            + str(MIN_CYTHON_VERSION)
-            + " to continue.\n"
-        )
-        sys.exit(1)
-    if LooseVersion(cyversion) < LooseVersion(MIN_CYTHON_VERSION):
-        sys.stdout.write(
-            "ERROR: Your Cython is at version '"
-            + str(cyversion)
-            + "', but at least version "
-            + str(MIN_CYTHON_VERSION)
-            + " is required.\n"
-        )
-        sys.exit(1)
 
 
 def CppExtension(name, sources):
@@ -126,7 +101,6 @@ class BuildExt(build_ext):
         else:
             # Otherwise, this is a 'developer copy' of the code, and then the
             # only sensible thing is to require Cython to be installed.
-            check_cython_version()
             from Cython.Build import cythonize
 
             self.extensions = cythonize(self.extensions)
@@ -152,7 +126,6 @@ class SDist(sdist):
         # Make sure the compiled Cython files in the distribution are up-to-date
         from Cython.Build import cythonize
 
-        check_cython_version()
         cythonize(self.distribution.ext_modules)
         super().run()
 

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,6 @@ from distutils.sysconfig import customize_compiler
 
 MIN_CYTHON_VERSION = "0.29"
 
-if sys.version_info < (3, 6):
-    sys.stdout.write("At least Python 3.6 is required.\n")
-    sys.exit(1)
-
 
 def no_cythonize(extensions, **_ignore):
     """

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ import os
 import os.path
 from setuptools import setup, Extension, find_packages
 from distutils.version import LooseVersion
-from distutils.command.sdist import sdist
-from distutils.command.build_ext import build_ext
+from setuptools.command.sdist import sdist
+from setuptools.command.build_ext import build_ext
 from distutils.sysconfig import customize_compiler
 
 MIN_CYTHON_VERSION = "0.29"

--- a/setup.py
+++ b/setup.py
@@ -193,7 +193,6 @@ setup(
     ext_modules=ext_modules,
     packages=find_packages(),
     entry_points={"console_scripts": ["whatshap = whatshap.__main__:main"]},
-    setup_requires=["setuptools_scm"],  # Support pip versions that don't know about pyproject.toml
     install_requires=install_requires,
     extras_require={"dev": ["Cython", "pytest", "sphinx", "sphinx_issues", "pysam-stubs"]},
     python_requires=">=3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ basepython = python3.7
 deps =
     twine
     cython
+    setuptools_scm
 commands =
     python setup.py sdist -d {envtmpdir}/dist
     twine check {envtmpdir}/dist/*


### PR DESCRIPTION
I had to yank the WhatsHap 1.2 release because I switched to `build-backend = "setuptools.build_meta"` in `pyproject.toml`, which for some reason caused neither `pyproject.toml` nor `setup.py` to be included in the tarball (sdist).

When fixing this, I had problems with the custom `BuildExt` class, which we modified to run `cythonize()` on the `.pyx` files. I simplified the build system a bit by assuming that Cython is always installed. This now works reliably due to `pyproject.toml`. We can then always run `cythonize`, which also allows us to get rid of the custom `SDist` class.

All this is simpler and more in line with current best practices for Cython projects.

I also added an extra test that just creates an sdist and builds a wheel from that. If that test had been in place, we would have seen the packaging problem earlier.

I don’t expect any feedback and will merge this as soon as the tests pass.