### PR TITLE
Use threads option of pysam for haplotag output

### DIFF
--- a/whatshap/cli/haplotag.py
+++ b/whatshap/cli/haplotag.py
@@ -20,7 +20,7 @@ from whatshap.cli import PhasedInputReader, CommandLineError
 from whatshap.vcf import VcfReader, VcfError, VariantTable, VariantCallPhase, VcfInvalidChromosome
 from whatshap.core import NumericSampleIds
 from whatshap.timer import StageTimer
-from whatshap.utils import Region
+from whatshap.utils import Region, stdout_is_regular_file
 
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ def add_arguments(parser):
         help='Skip reads that map to a contig that does not exist in the VCF')
     arg('--out-threads', default=1, type=int,
         help='Number of threads to use for output file writing (passed to pysam). '
-        'For optimal performance, instead write output to stdout and use `samtools view` to compress.')
+        'For optimal performance, instead write output to stdout and use "samtools view" to compress.')
     arg('variant_file', metavar='VCF', help='VCF file with phased variants (must be gzip-compressed and indexed)')
     arg('alignment_file', metavar='ALIGNMENTS',
         help='File (BAM/CRAM) with read alignments to be tagged by haplotype')
@@ -381,8 +381,8 @@ def open_output_alignment_file(aln_output, reference, vcf_md5, bam_header, threa
             )
         kwargs = dict(mode="wc", reference_filename=reference)
     else:
-        # Write BAM, disable compression for stdout
-        if aln_output is sys.stdout:
+        # Write BAM, disable compression when piping
+        if aln_output is sys.stdout and not stdout_is_regular_file():
             kwargs = dict(mode="wb0", threads=threads)
         else:
             kwargs = dict(mode="wb", threads=threads)

--- a/whatshap/cli/haplotag.py
+++ b/whatshap/cli/haplotag.py
@@ -459,7 +459,7 @@ def run_haplotag(
     haplotag_list=None,
     tag_supplementary=False,
     skip_missing_contigs=False,
-    out_threads=1
+    out_threads=1,
 ):
 
     timers = StageTimer()
@@ -505,7 +505,11 @@ def run_haplotag(
 
         bam_writer = stack.enter_context(
             open_output_alignment_file(
-                output, reference, md5_of(variant_file), bam_reader.header.to_dict(), threads=out_threads
+                output,
+                reference,
+                md5_of(variant_file),
+                bam_reader.header.to_dict(),
+                threads=out_threads,
             )
         )
         haplotag_writer = stack.enter_context(open_haplotag_writer(haplotag_list))

--- a/whatshap/utils.py
+++ b/whatshap/utils.py
@@ -1,7 +1,10 @@
+from collections import defaultdict
 import gzip
 import logging
-from collections import defaultdict
 from typing import Optional, DefaultDict
+import os
+import stat
+import sys
 
 import pyfaidx
 from dataclasses import dataclass
@@ -39,6 +42,16 @@ def detect_file_format(path):
                 return "VCF"
 
     return None
+
+
+def stdout_is_regular_file() -> bool:
+    """
+    Detect if standard output is a regular file (or say a pipe).
+
+    :return: True if stdout is a regular file, else False.
+    """
+    mode = os.fstat(sys.stdout.buffer.fileno()).st_mode
+    return stat.S_ISREG(mode)
 
 
 def IndexedFasta(path):


### PR DESCRIPTION
`whatshap haplotag` is used in a number of pipelines including [clair3](https://github.com/HKU-BAL/Clair3)'s variant calling. In these pipelines it can be a bottleneck since a) its a fairly slow serial step b) it usually occurs in a synchronisation step so no other tasks can be accomplised until the tagging has finished.

A quick profiling reveals 25% of time is spent on the line:
```
for alignment in bam_reader.fetch(contig=chrom, start=start, stop=end):
```
and 50% of the time is spent on the line:
```
bam_writer.write(alignment)
```
with the rest of the time being spent on more productive matters.

This PR alleviates some of the bottleneck that `whatshap haplotag` can cause by exposing the threads option of the `pysam.AlignmentFile` class to allow use of an htslib threadpool for output compression. Setting this parameter to 4-8 threads I have observed a 2-3.5X improvement in the wall time execution speed of `whatshap haplotag`.

The program is also now at the point where the loading of variants and preparation of haplotag information is taking as long as the read tagging loop. The bulk (88%) of `prepare_haplotag_information` is spent on the line:
```
read_set, _ = phased_input_reader.read(
    variant_table.chromosome, variants, sample, regions=regions
)
```