### PR TITLE
Cluster editing speedup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ development version
   back to the less accurate algorithm.
 * :issue:`371`: ``whatshap split`` crashed when attempting to split
   reads in a FASTQ file by haplotype.
+* :pr:`377`: Speed-up of about 20-30% for ``whatshap polyphase`` via
+  some optimizations in the read clustering algorithm.
 
 v1.4 (2022-04-07)
 -----------------

--- a/src/polyphase/inducedcostheuristic.h
+++ b/src/polyphase/inducedcostheuristic.h
@@ -45,7 +45,7 @@ private:
      * All implications are resolved then.
      */
     void choosePermanentEdge(const StaticSparseGraph::Edge eIcf);
-        
+
     /**
      * Invoked, when the heuristic decides the make the specified edge forbidden.
      * All implications are resolved then.

--- a/src/polyphase/inducedcostheuristic.h
+++ b/src/polyphase/inducedcostheuristic.h
@@ -45,7 +45,7 @@ private:
      * All implications are resolved then.
      */
     void choosePermanentEdge(const StaticSparseGraph::Edge eIcf);
-    
+        
     /**
      * Invoked, when the heuristic decides the make the specified edge forbidden.
      * All implications are resolved then.

--- a/src/polyphase/staticsparsegraph.h
+++ b/src/polyphase/staticsparsegraph.h
@@ -219,15 +219,6 @@ private:
      * Removes a specific node id from the vector.
      */
     bool removeFromVector(std::vector<NodeId>& vec, NodeId v);
-    
-    std::string int2bin(uint64_t u) {
-        std::string s(64, '0');
-        uint64_t mask = (1UL << 63); // fill in values right-to-left
-        for (int i = 0; i < 64; i++, mask >>= 1)
-            if ((u & mask) != 0)
-                s[i] = '1';
-        return s;
-    }
 };
 
 #endif

--- a/src/polyphase/trianglesparsematrix.h
+++ b/src/polyphase/trianglesparsematrix.h
@@ -1,10 +1,11 @@
 #ifndef TRIANGLESPARSEMATRIX_H
 #define TRIANGLESPARSEMATRIX_H
 
-#include <cstdint>
 #include <unordered_map>
 #include <set>
 #include <vector>
+#include <cmath>
+#include <stdint.h>
 
 /**
  * A simple storage class, to sparsely store float values for pairs of non-negative integers.

--- a/tests/test_clusterediting.py
+++ b/tests/test_clusterediting.py
@@ -30,7 +30,7 @@ def test_similarities2():
     """
     readset = string_to_readset(reads)
     similarities = scoreReadset(readset, 4, 4, 0.06)
-    
+
     assert similarities.get(0, 1) > 1.0
     assert similarities.get(0, 1) == similarities.get(0, 2) == similarities.get(0, 3)
     assert similarities.get(0, 1) == similarities.get(1, 2) == similarities.get(1, 3)
@@ -40,7 +40,8 @@ def test_similarities2():
     assert similarities.get(0, 7) < -1.0
     assert similarities.get(4, 5) > 1.0
     assert similarities.get(4, 6) < -1.0
-    
+
+
 def test_similarities3():
     reads = """
     00000
@@ -54,7 +55,7 @@ def test_similarities3():
     """
     readset = string_to_readset(reads)
     similarities = scoreReadset(readset, 4, 2, 0.06)
-    
+
     assert similarities.get(0, 1) > 5.0
     assert similarities.get(0, 1) == similarities.get(0, 2) == similarities.get(0, 3)
     assert similarities.get(0, 1) == similarities.get(1, 2) == similarities.get(1, 3)
@@ -65,44 +66,47 @@ def test_similarities3():
     assert similarities.get(4, 5) > 1.0
     assert similarities.get(4, 6) > 1.0
 
+
 def test_similarities4():
     reads = """
     000
      000
       000
-    111  
-     111 
+    111
+     111
       101
-     110 
+     110
     """
     readset = string_to_readset(reads)
     similarities = scoreReadset(readset, 2, 2, 0.06)
-    
+
     assert similarities.get(0, 1) > 2.0
     assert similarities.get(0, 2) == 0.0
     assert similarities.get(1, 2) > 2.0
     assert similarities.get(0, 3) < -5.0 < similarities.get(1, 3) < 0.0 == similarities.get(2, 3)
     assert similarities.get(4, 6) > similarities.get(4, 5) > 0.0
-    
+
+
 def test_similarities5():
     reads = """
     000
      000
       000
-    111  
-     111 
+    111
+     111
       101
-     110 
+     110
     """
     readset = string_to_readset(reads)
     similarities = scoreReadset(readset, 2, 3, 0.06)
-    
+
     assert similarities.get(0, 1) > 1.0
     assert similarities.get(0, 2) == 0.0
     assert similarities.get(1, 2) > 0.5
     assert similarities.get(0, 3) < -5.0 < similarities.get(1, 3) < 0.0 == similarities.get(2, 3)
     assert 0.0 > similarities.get(4, 6) > similarities.get(4, 5)
-    
+
+
 def test_clusterediting1():
 
     reads = """
@@ -139,7 +143,7 @@ def test_clusterediting1():
     read_ids = list(itertools.chain.from_iterable(readpartitioning))
     duplicates = set([r for r in read_ids if read_ids.count(r) > 1])
     assert len(duplicates) == 0
-    
+
     assert any(all(x in c for x in [0, 1, 2, 4, 9, 11, 13]) for c in readpartitioning)
     assert any(all(x in c for x in [3, 7, 10, 14]) for c in readpartitioning)
     assert any(all(x in c for x in [5, 8]) for c in readpartitioning)
@@ -161,18 +165,18 @@ def test_clusterediting2():
 
     # construct a ReadSet
     readset = string_to_readset(reads)
-    
+
     # compute similarities
     similarities = scoreReadset(readset, 3, 2, 0.06)
 
     # run cluster editing
     clusterediting = ClusterEditingSolver(similarities, False)
     readpartitioning = clusterediting.run()
-    
+
     assert any(all(x in c for x in [0, 2, 4, 5]) for c in readpartitioning)
     assert any(all(x in c for x in [1, 3, 6, 7, 8]) for c in readpartitioning)
-    
-    
+
+
 def test_clusterediting3():
 
     reads = """
@@ -189,14 +193,14 @@ def test_clusterediting3():
 
     # construct a ReadSet
     readset = string_to_readset(reads)
-    
+
     # compute similarities
     similarities = scoreReadset(readset, 3, 2, 0.06)
 
     # run cluster editing
     clusterediting = ClusterEditingSolver(similarities, False)
     readpartitioning = clusterediting.run()
-    
+
     assert any(all(x in c for x in [0, 2, 4, 5]) for c in readpartitioning)
     assert any(all(x in c for x in [1, 3, 6, 7, 8]) for c in readpartitioning)
 
@@ -227,7 +231,7 @@ def test_clusterediting4():
     assert any(all(x in c for x in [0, 2, 3, 6, 8, 9]) for c in readpartitioning)
     assert any(all(x in c for x in [1, 4, 5, 7]) for c in readpartitioning)
 
-    
+
 def test_clusterediting5():
     reads = """
     0010111110111111111001111

--- a/tests/test_clusterediting.py
+++ b/tests/test_clusterediting.py
@@ -5,20 +5,118 @@ from whatshap.core import ClusterEditingSolver, scoreReadset
 from whatshap.testhelpers import string_to_readset
 
 
+def test_similarities1():
+    reads = """
+    001001
+    110101
+    """
+    readset = string_to_readset(reads)
+    similarities = scoreReadset(readset, 4, 2, 0.06)
+
+    assert not math.isnan(similarities.get(0, 1))
+    assert similarities.get(0, 1) < -6.0
+
+
+def test_similarities2():
+    reads = """
+    00000
+    00000
+    00000
+    00000
+    11111
+    11111
+    10101
+    10101
+    """
+    readset = string_to_readset(reads)
+    similarities = scoreReadset(readset, 4, 4, 0.06)
+    
+    assert similarities.get(0, 1) > 1.0
+    assert similarities.get(0, 1) == similarities.get(0, 2) == similarities.get(0, 3)
+    assert similarities.get(0, 1) == similarities.get(1, 2) == similarities.get(1, 3)
+    assert similarities.get(0, 4) < -8.0
+    assert similarities.get(0, 5) < -8.0
+    assert similarities.get(0, 6) < -1.0
+    assert similarities.get(0, 7) < -1.0
+    assert similarities.get(4, 5) > 1.0
+    assert similarities.get(4, 6) < -1.0
+    
+def test_similarities3():
+    reads = """
+    00000
+    00000
+    00000
+    00000
+    11111
+    11111
+    10101
+    10101
+    """
+    readset = string_to_readset(reads)
+    similarities = scoreReadset(readset, 4, 2, 0.06)
+    
+    assert similarities.get(0, 1) > 5.0
+    assert similarities.get(0, 1) == similarities.get(0, 2) == similarities.get(0, 3)
+    assert similarities.get(0, 1) == similarities.get(1, 2) == similarities.get(1, 3)
+    assert similarities.get(0, 4) < -8.0
+    assert similarities.get(0, 5) < -8.0
+    assert similarities.get(0, 6) < -1.0
+    assert similarities.get(0, 7) < -1.0
+    assert similarities.get(4, 5) > 1.0
+    assert similarities.get(4, 6) > 1.0
+
+def test_similarities4():
+    reads = """
+    000
+     000
+      000
+    111  
+     111 
+      101
+     110 
+    """
+    readset = string_to_readset(reads)
+    similarities = scoreReadset(readset, 2, 2, 0.06)
+    
+    assert similarities.get(0, 1) > 2.0
+    assert similarities.get(0, 2) == 0.0
+    assert similarities.get(1, 2) > 2.0
+    assert similarities.get(0, 3) < -5.0 < similarities.get(1, 3) < 0.0 == similarities.get(2, 3)
+    assert similarities.get(4, 6) > similarities.get(4, 5) > 0.0
+    
+def test_similarities5():
+    reads = """
+    000
+     000
+      000
+    111  
+     111 
+      101
+     110 
+    """
+    readset = string_to_readset(reads)
+    similarities = scoreReadset(readset, 2, 3, 0.06)
+    
+    assert similarities.get(0, 1) > 1.0
+    assert similarities.get(0, 2) == 0.0
+    assert similarities.get(1, 2) > 0.5
+    assert similarities.get(0, 3) < -5.0 < similarities.get(1, 3) < 0.0 == similarities.get(2, 3)
+    assert 0.0 > similarities.get(4, 6) > similarities.get(4, 5)
+    
 def test_clusterediting1():
 
     reads = """
         110000010111
         1100000101
          1000 01
-         00 0 0 000
+         00 0 0 010
          1000001 11
           1111101
           0 10010 1
            0000 010
            1110
            0000 011
-            000  00
+            000  10
             0001011
             0  10110
             00010111
@@ -29,7 +127,7 @@ def test_clusterediting1():
     readset = string_to_readset(reads)
 
     # compute similarities
-    similarities = scoreReadset(readset, 5, 4)
+    similarities = scoreReadset(readset, 3, 3, 0.06)
 
     # run cluster editing
     clusterediting = ClusterEditingSolver(similarities, False)
@@ -40,8 +138,11 @@ def test_clusterediting1():
     # make sure each read occurs only once
     read_ids = list(itertools.chain.from_iterable(readpartitioning))
     duplicates = set([r for r in read_ids if read_ids.count(r) > 1])
-    print("duplicates:", duplicates)
     assert len(duplicates) == 0
+    
+    assert any(all(x in c for x in [0, 1, 2, 4, 9, 11, 13]) for c in readpartitioning)
+    assert any(all(x in c for x in [3, 7, 10, 14]) for c in readpartitioning)
+    assert any(all(x in c for x in [5, 8]) for c in readpartitioning)
 
 
 def test_clusterediting2():
@@ -60,29 +161,52 @@ def test_clusterediting2():
 
     # construct a ReadSet
     readset = string_to_readset(reads)
-
+    
     # compute similarities
-    similarities = scoreReadset(readset, 5, 2)
-    print(similarities)
+    similarities = scoreReadset(readset, 3, 2, 0.06)
 
     # run cluster editing
     clusterediting = ClusterEditingSolver(similarities, False)
     readpartitioning = clusterediting.run()
-
-    print("computed clusters: ", readpartitioning)
-
-    # make sure each read occurs only once
-    read_ids = list(itertools.chain.from_iterable(readpartitioning))
-    duplicates = set([r for r in read_ids if read_ids.count(r) > 1])
-    print("duplicates:", duplicates)
-    assert len(duplicates) == 0
-
-
+    
+    assert any(all(x in c for x in [0, 2, 4, 5]) for c in readpartitioning)
+    assert any(all(x in c for x in [1, 3, 6, 7, 8]) for c in readpartitioning)
+    
+    
 def test_clusterediting3():
+
+    reads = """
+        000000 00 0 00000 0000 0
+             1111 11111
+               000 00000 0000000
+               111111111
+                 1000000000
+                  0 00000
+                    11111
+                    1 1 1111 1111111111
+                    111111111111
+        """
+
+    # construct a ReadSet
+    readset = string_to_readset(reads)
+    
+    # compute similarities
+    similarities = scoreReadset(readset, 3, 2, 0.06)
+
+    # run cluster editing
+    clusterediting = ClusterEditingSolver(similarities, False)
+    readpartitioning = clusterediting.run()
+    
+    assert any(all(x in c for x in [0, 2, 4, 5]) for c in readpartitioning)
+    assert any(all(x in c for x in [1, 3, 6, 7, 8]) for c in readpartitioning)
+
+
+def test_clusterediting4():
     reads = """
     0010111110111111111001111
     111111111111111111111 111
     011011111011111 111001111
+    00101 111011111 1110011 1
      11 11111111 111111111111
     1111111111111111111111 11
     0010111110111111111001111
@@ -94,39 +218,39 @@ def test_clusterediting3():
     readset = string_to_readset(reads)
 
     # compute similarities
-    similarities = scoreReadset(readset, 5, 3)
-    print(similarities)
+    similarities = scoreReadset(readset, 5, 3, 0.06)
 
     # run cluster editing
     clusterediting = ClusterEditingSolver(similarities, False)
     readpartitioning = clusterediting.run()
 
-    print("computed clusters: ", readpartitioning)
+    assert any(all(x in c for x in [0, 2, 3, 6, 8, 9]) for c in readpartitioning)
+    assert any(all(x in c for x in [1, 4, 5, 7]) for c in readpartitioning)
 
-
-def test_similarities1():
+    
+def test_clusterediting5():
     reads = """
-    001001
-    110101
+    0010111110111111111001111
+    111111111111111111111 111
+    011011111011111 111001111
+    00101 111011111 1110011 1
+     11 11111111 111111111111
+    1111111111111111111111 11
+    0010111110111111111001111
+    111111111111111111111 111
+    011011111011111 111001111
+    011011111011111 111001111
     """
+    # construct a ReadSet
     readset = string_to_readset(reads)
-    similarities = scoreReadset(readset, 4, 2)
-    # computed similarity is 'nan'
-    print("computed similarities:", similarities)
-    assert not math.isnan(similarities.get(0, 1))
 
+    # compute similarities
+    similarities = scoreReadset(readset, 5, 3, 0.01)
 
-def test_similarities2():
-    reads = """
-    00000
-    00000
-    00000
-    00000
-    11111
-    11111
-    10101
-    10101
-    """
-    readset = string_to_readset(reads)
-    similarities = scoreReadset(readset, 4, 4)
-    print("computed similarities:", similarities)
+    # run cluster editing
+    clusterediting = ClusterEditingSolver(similarities, False)
+    readpartitioning = clusterediting.run()
+
+    assert any(all(x in c for x in [0, 3, 6]) for c in readpartitioning)
+    assert any(all(x in c for x in [1, 4, 5, 7]) for c in readpartitioning)
+    assert any(all(x in c for x in [2, 8, 9]) for c in readpartitioning)


### PR DESCRIPTION
I found a nice shortcut in the cluster editing heuristic, which does not change the results (or at least it should not and I did not find any differences so far), but makes the heuristic run in less than a third of the old time. This makes the regular polyphase algorithm 20-30% faster. The upcoming genetic polyphase should profit much more, because the cluster editing is much more of a bottleneck there, at least on large instances. I also added/updates the testcases for cluster editing.

I did not edit the `CHANGES.rst` yet, because I first wanted to wait for approval.