### PR TITLE
whatshap stats - Update NG50 calculation

### DIFF
--- a/tests/data/phased_overlapping.vcf
+++ b/tests/data/phased_overlapping.vcf
@@ -1,0 +1,18 @@
+##fileformat=VCFv4.1
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set">
+##contig=<ID=chrA,length=1000>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1
+chrA	100	.	A	T	500.0	.	.	GT:PS	0|1:1
+chrA	150	.	C	GGG	500.0	.	.	GT:PS	1|0:1
+chrA	300	.	G	T	500.0	.	.	GT:PS	1|0:1
+chrA	350	.	GAG	T	500.0	.	.	GT:PS	1|0:1
+chrA	410	.	C	T	500.0	.	.	GT:PS	0|1:2
+chrA	460	.	G	T	500.0	.	.	GT:PS	0|1:2
+chrA	470	.	G 	A	500.0	.	.	GT:PS	0|1:2
+chrA	500	.	C	T	500.0	.	.	GT:PS	0|1:1
+chrA	600	.	T	T	500.0	.	.	GT:PS	0|1:1
+chrA	700	.	GA	TC	500.0	.	.	GT:PS	0|1:1
+chrA	800	.	C	G	500.0	.	.	GT:PS	0|1:3
+chrA	900	.	C	T	500.0	.	.	GT:PS	0|1:3
+chrA	950	.	G	TA	500.0	.	.	GT:PS	0|1:3

--- a/tests/test_run_stats.py
+++ b/tests/test_run_stats.py
@@ -85,3 +85,46 @@ def test_stats2(tmp_path):
     assert entry_all.variant_per_block_sum == "8"
     assert entry_all.bp_per_block_sum == "750"
     assert entry_all.block_n50[:-1] == "350"
+
+
+def test_overlapping_phaseblocks(tmp_path):
+    """
+    We have three phaseblocks on chrA which is 1000 bp
+
+        chrA:100-700 --> 600 bp
+        chrA:410-470 --> 60 bp
+        chrA:800-950 --> 150 bp
+
+    Total block sum should be 600 + 60 + 150 = 810 bp
+
+    For NG50 the first block is split since the second block overlaps, now we have four blocks
+
+        chrA:100-350 --> 250 bp
+        chrA:410-470 --> 60 bp
+        chrA:500-700 --> 200 bp
+        chrA:800-950 --> 150 bp
+
+    Half of the total length is 1000 * 0.5 = 500 bp.
+    Let's calculate NG50 by adding block lengths in descending order until we exceed 500 bp
+
+        block   length  total   >500
+        1       250     250     no
+        2       200     450     no
+        3       150     600     yes ->  NG50 = 150 bp
+    """
+
+    outtsv = tmp_path / "output.tsv"
+    run_stats(
+        vcf="tests/data/phased_overlapping.vcf",
+        tsv=outtsv,
+        sample="sample1",
+    )
+    lines = [l.split("\t") for l in open(outtsv)]
+    assert len(lines) == 2
+    Fields = namedtuple("Fields", [f.strip("#\n") for f in lines[0]])
+    entry = Fields(*lines[1])
+
+    assert entry.chromosome == "chrA"
+    assert entry.blocks == "3"
+    assert entry.bp_per_block_sum == "810"
+    assert entry.block_n50[:-1] == "150"

--- a/tests/test_run_stats.py
+++ b/tests/test_run_stats.py
@@ -13,7 +13,8 @@ def test_stats1(tmp_path):
         sample="sample1",
         chr_lengths="tests/data/chr-lengths.txt",
     )
-    lines = [l.split("\t") for l in open(outtsv)]
+    with open(outtsv) as f:
+        lines = [l.split("\t") for l in f]
     assert len(lines) == 4
     Fields = namedtuple("Fields", [f.strip("#\n") for f in lines[0]])
     entry_chrA, entry_chrB, entry_all = [Fields(*l) for l in lines[1:]]
@@ -54,7 +55,8 @@ def test_stats2(tmp_path):
         sample="sample1",
         chr_lengths="tests/data/chr-lengths.txt",
     )
-    lines = [l.split("\t") for l in open(outtsv)]
+    with open(outtsv) as f:
+        lines = [l.split("\t") for l in f]
     assert len(lines) == 4
     Fields = namedtuple("Fields", [f.strip("#\n") for f in lines[0]])
     entry_chrA, entry_chrB, entry_all = [Fields(*l) for l in lines[1:]]
@@ -119,7 +121,8 @@ def test_overlapping_phaseblocks(tmp_path):
         tsv=outtsv,
         sample="sample1",
     )
-    lines = [l.split("\t") for l in open(outtsv)]
+    with open(outtsv) as f:
+        lines = [l.split("\t") for l in f]
     assert len(lines) == 2
     Fields = namedtuple("Fields", [f.strip("#\n") for f in lines[0]])
     entry = Fields(*lines[1])

--- a/whatshap/cli/stats.py
+++ b/whatshap/cli/stats.py
@@ -161,7 +161,7 @@ def compute_ng50(blocks, chr_lengths):
             )
             return float("nan")
 
-    block_lengths = [b.rightmost_variant.position-b.leftmost_variant.position for b in blocks]
+    block_lengths = [b.rightmost_variant.position - b.leftmost_variant.position for b in blocks]
     return n50(block_lengths, target_length=target_length)
 
 

--- a/whatshap/cli/stats.py
+++ b/whatshap/cli/stats.py
@@ -213,13 +213,13 @@ class PhasingStats:
         while pos_sorted_blocks:
             block = pos_sorted_blocks.pop()
             if pos_sorted_blocks:
-                start, end = block.leftmost_variant.position, block.rightmost_variant.position
+                block_end = block.rightmost_variant.position
                 next_block = pos_sorted_blocks[-1]
                 next_block_start = next_block.leftmost_variant.position
                 next_block_end = next_block.rightmost_variant.position
 
                 # Check if next block overlapps current. If so split the current block.
-                if (end > next_block_start) and (block.chromosome == next_block.chromosome):
+                if (block_end > next_block_start) and (block.chromosome == next_block.chromosome):
                     block, new_block = block.split(next_block_start, next_block_end)
 
                     # Update sorting if right-side block is added.


### PR DESCRIPTION
Split interleaved phase blocks to maintain as much of the phased variants as possible. This will make NG50 values a bit more fair compared to how they were calculated previously. 

If one phase block is fully encompassed by another block the inner block would determine the end of the outer block on the left side. The right side variants in the outer block were however scrapped in the current version leading to some deflation of the NG50 value. 

I made a small example below to clarify.

**Original phase blocks**
```
Phase block 1:    A--G--G--T----C------C--T--C
Phase block 2:               A----G--C
```


**Previous split**
```
Phase block 1:   A--G--G--T
Phase block 2:              A--G--C
```

**Updated split**
```
Phase block 1.1:  A--G--G--T
Phase block 1.2:                       C--T--C
Phase block 2:               A--G--C
```