### PR TITLE
whatshap stats - Speed up chromosome lookup 

### DIFF
--- a/whatshap/cli/stats.py
+++ b/whatshap/cli/stats.py
@@ -460,7 +460,7 @@ def run_stats(
 
             total_stats += stats
 
-            if given_chromosomes and all(c in seen_chromosomes for c in given_chromosomes):
+            if given_chromosomes and set(given_chromosomes) <= seen_chromosomes:
                 break
 
         if chromosome_count > 1:

--- a/whatshap/cli/stats.py
+++ b/whatshap/cli/stats.py
@@ -382,8 +382,10 @@ def run_stats(
         total_stats = PhasingStats()
         chromosome_count = 0
         given_chromosomes = chromosomes
+        seen_chromosomes = set()
         for variant_table in parse_variant_tables(vcf_reader, given_chromosomes):
             if given_chromosomes:
+                seen_chromosomes.add(variant_table.chromosome)
                 if variant_table.chromosome not in given_chromosomes:
                     continue
             chromosome_count += 1
@@ -457,6 +459,9 @@ def run_stats(
                 print(*dataclasses.astuple(stats.get(chr_lengths)), sep="\t", file=tsv_file)
 
             total_stats += stats
+
+            if given_chromosomes and all(c in seen_chromosomes for c in given_chromosomes):
+                break
 
         if chromosome_count > 1:
             print("---------------- ALL chromosomes (aggregated) ----------------")

--- a/whatshap/cli/stats.py
+++ b/whatshap/cli/stats.py
@@ -299,6 +299,18 @@ def parse_chr_lengths(filename):
     return chr_lengths
 
 
+def parse_variant_tables(vcf_reader, chromosomes=None):
+    """
+    Parse variant_tables from vcf_reader. If chromosomes are given and VCF is indexed,
+    theses are accessed by direct lookup.
+    """
+    if chromosomes and vcf_reader.index_exists():
+        for chromosome in chromosomes:
+            yield vcf_reader.fetch(chromosome)
+    else:
+        yield from vcf_reader
+
+
 def run_stats(
     vcf,
     sample=None,
@@ -370,7 +382,7 @@ def run_stats(
         total_stats = PhasingStats()
         chromosome_count = 0
         given_chromosomes = chromosomes
-        for variant_table in vcf_reader:
+        for variant_table in parse_variant_tables(vcf_reader, given_chromosomes):
             if given_chromosomes:
                 if variant_table.chromosome not in given_chromosomes:
                     continue

--- a/whatshap/vcf.py
+++ b/whatshap/vcf.py
@@ -387,6 +387,10 @@ class VcfReader:
     def path(self) -> str:
         return self._vcf_reader.filename.decode()
 
+    def index_exists(self) -> bool:
+        """ "Check if VCF is indexed (.tbi or .csi)"""
+        return os.path.isfile(f"{self.path}.tbi") or os.path.isfile(f"{self.path}.csi")
+
     def _fetch(self, chromosome: str, start: int = 0, end: Optional[int] = None):
         try:
             records = self._vcf_reader.fetch(chromosome, start=start, stop=end)

--- a/whatshap/vcf.py
+++ b/whatshap/vcf.py
@@ -389,7 +389,7 @@ class VcfReader:
 
     def index_exists(self) -> bool:
         """ "Check if VCF is indexed (.tbi or .csi)"""
-        return os.path.isfile(f"{self.path}.tbi") or os.path.isfile(f"{self.path}.csi")
+        return self._vcf_reader.index is not None
 
     def _fetch(self, chromosome: str, start: int = 0, end: Optional[int] = None):
         try:


### PR DESCRIPTION
I noticed that when using `whatshap stats` with `--chromosomes` the entire VCF is still read, which is very slow. This PR does two things. 

- If the VCF is indexed (.tbi or .csi) --> lookup chromosomes of interest (given by `--chromosomes`) directly
- If the VCF is not indexed --> stop reading if all chromosomes of intest have been seen