### PR TITLE
whatshap stats - Calculate all length statistics on split blocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,13 +2,18 @@
 Changes
 =======
 
+development version
+-------------------
+
+* :issue:`400`: Fixed artificial overinflation of block length stats in ``whatshap stats``.
+
 v1.6 (2022-09-06)
 -----------------
 
 * :pr:`384`: Fixed how interleaved phase blocks in ``whatshap stats`` are split
   when computing NG50 values. This allows NG50 values to be larger than before.
   Thanks to @pontushojer.
-* :pr:`385`: Sped up ``whatshap stats`` when used with ``--chromosomes`` by avoiding to
+* :pr:`385`: Speed up ``whatshap stats`` when used with ``--chromosomes`` by avoiding to
   read in the entire VCF. Thanks to @pontushojer.
 * :pr:`387`: ``whatshap haplotag`` got some optimizations and is now about 20% faster.
   Thanks to @pontushojer.

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -577,21 +577,26 @@ variant_per_block_sum
     Median number of variants, average (mean) number of variants, minimum number of variants, maximum number of variants, sum of the number of variants.
     (To Do: It should be the case that singletons + variant_per_block_sum = phased)
 
+The following columns describe the distribution of non-singleton block lengths, where the length of a block is the *number of basepairs* it covers minus
+1. That is, a block with two variants at positions 2 and 5 has length 3. Interleaved blocks are cut in order to avoid artificially inflating this value.
+
 bp_per_block_median
+    Median block length.
 
 bp_per_block_avg
+    Average (mean) block length.
 
 bp_per_block_min
+    Minimum block length.
 
 bp_per_block_max
+    Maximum block length.
 
 bp_per_block_sum
-    Description of the distribution of non-singleton block lengths, where the length of a block is the *number of basepairs* it covers minus 1. That is, a block with two variants at positions 2 and 5 has length 3.
-    Median length, average (mean) length minimum length, maximum length, sum of lengths.
+    Total sum of block lengths.
 
 block_n50
     The NG50 value of the distribution of the block lengths.
-    Interleaved blocks are cut in order to avoid artificially inflating this value.
 
     Note that this is an "NG50" (not "N50"), that is, the threshold of 50% is
     relative to the true length of the contig as reported in the VCF header.

--- a/tests/test_run_stats.py
+++ b/tests/test_run_stats.py
@@ -106,6 +106,7 @@ def test_overlapping_phaseblocks(tmp_path):
         chrA:500-700 --> 200 bp
         chrA:800-950 --> 150 bp
 
+    Total block sum is now 250 + 60 + 200 + 150 = 660 bp
     Half of the total length is 1000 * 0.5 = 500 bp.
     Let's calculate NG50 by adding block lengths in descending order until we exceed 500 bp
 
@@ -129,5 +130,5 @@ def test_overlapping_phaseblocks(tmp_path):
 
     assert entry.chromosome == "chrA"
     assert entry.blocks == "3"
-    assert entry.bp_per_block_sum == "810"
+    assert entry.bp_per_block_sum == "660"
     assert entry.block_n50[:-1] == "150"

--- a/whatshap/cli/stats.py
+++ b/whatshap/cli/stats.py
@@ -296,7 +296,7 @@ class PhasingStats:
         n_singletons = sum(1 for size in block_sizes if size == 1)
         block_sizes = [size for size in block_sizes if size > 1]
         # Block length stats calculated from split interleaved blocks to avoid inflating values
-        block_lengths = sorted([block.span() for block in self.split_blocks if len(block) > 1])
+        block_lengths = sorted(block.span() for block in self.split_blocks if len(block) > 1)
         phased_snvs = sum(block.count_snvs() for block in self.blocks if len(block) > 1)
         if block_sizes:
             return DetailedStats(


### PR DESCRIPTION
fix #400 

Fixes inflated stats for block lengths in `whatshap stats` if there are overlapping blocks, also see  https://github.com/whatshap/whatshap/pull/384. 

I tested on chromosome `SUPER_3` (116801625 bp) in the VCF referenced in issue #400 where there were a lot of overlapping blocks. 
**Before** 
```
      Sum of lengths: 1036875048    bp
 Median block length:        493.00 bp
Average block length:      16018.71 bp
       Longest block:   75095876    bp
      Shortest block:          1    bp
          Block NG50:          0    bp
```

**After**
```
      Sum of lengths: 48207739    bp
 Median block length:      492.00 bp
Average block length:      744.53 bp
       Longest block:    15389    bp
      Shortest block:        1    bp
          Block NG50:        0    bp
```

As you can see there is a drastic reduction in `Sum of lengths`, `Average block length` and `Longest block`. 

This PR also a removes an additional call to `PhasingStats.get` (now renamed `PhasingStats.get_detailed_stats`) when using the flag `--tsv`. 