### PR TITLE
Add #include <cstdint> where needed

### DIFF
--- a/src/genotype.h
+++ b/src/genotype.h
@@ -1,6 +1,7 @@
 #ifndef GENOTYPE_H
 #define GENOTYPE_H
 
+#include<cstdint>
 #include<vector>
 #include<set>
 #include<string>

--- a/src/polyphase/allelematrix.h
+++ b/src/polyphase/allelematrix.h
@@ -4,7 +4,7 @@
 #include <unordered_map>
 #include <vector>
 #include <cmath>
-#include <stdint.h>
+#include <cstdint>
 #include "../readset.h"
 #include "../read.h"
 

--- a/src/polyphase/haplothreader.h
+++ b/src/polyphase/haplothreader.h
@@ -1,6 +1,7 @@
 #ifndef HAPLOTHREADER_H
 #define HAPLOTHREADER_H
 
+#include <cstdint>
 #include "tuple.h"
 #include "tupleconverter.h"
 #include <vector>

--- a/src/polyphase/inducedcostheuristic.h
+++ b/src/polyphase/inducedcostheuristic.h
@@ -1,6 +1,7 @@
 #ifndef INDUCEDCOSTHEURISTIC_H
 #define INDUCEDCOSTHEURISTIC_H
 
+#include <cstdint>
 #include "edgeheap.h"
 #include "clustereditingsolution.h"
 

--- a/src/polyphase/readscoring.h
+++ b/src/polyphase/readscoring.h
@@ -1,6 +1,7 @@
 #ifndef READSCORING_H
 #define READSCORING_H
 
+#include <cstdint>
 #include "../readset.h"
 #include "../read.h"
 #include "../genotype.h"

--- a/src/polyphase/staticsparsegraph.h
+++ b/src/polyphase/staticsparsegraph.h
@@ -1,6 +1,7 @@
 #ifndef STATICSPARSEGRAPH_H
 #define STATICSPARSEGRAPH_H
 
+#include <cstdint>
 #include <vector>
 #include <map>
 #include <iostream>

--- a/src/polyphase/switchflipcalculator.h
+++ b/src/polyphase/switchflipcalculator.h
@@ -1,6 +1,7 @@
 #ifndef SWITCHFLIP_H
 #define SWITCHFLIP_H
 
+#include <cstdint>
 #include <vector>
 #include <unordered_map>
 #include <cmath>

--- a/src/polyphase/trianglesparsematrix.h
+++ b/src/polyphase/trianglesparsematrix.h
@@ -5,7 +5,7 @@
 #include <set>
 #include <vector>
 #include <cmath>
-#include <stdint.h>
+#include <cstdint>
 
 /**
  * A simple storage class, to sparsely store float values for pairs of non-negative integers.

--- a/src/polyphase/tuple.h
+++ b/src/polyphase/tuple.h
@@ -1,6 +1,7 @@
 #ifndef TUPLE_H
 #define TUPLE_H
 
+#include <cstdint>
 #include <vector>
 #include <cmath>
 #include <iostream>

--- a/src/polyphase/tupleconverter.h
+++ b/src/polyphase/tupleconverter.h
@@ -20,6 +20,7 @@
 #define TUPLECONVERTER_H
 
 #include "tuple.h"
+#include <cstdint>
 #include <vector>
 #include <unordered_map>
 #include <cmath>


### PR DESCRIPTION
The libstdc++ packaged with GCC 13.2.0 (and possibly earlier versions) requires <cstdint> to be explicitly included in places where it may have been implicitly included before.