### PR TITLE
Issue 498

### DIFF
--- a/src/binomial.cpp
+++ b/src/binomial.cpp
@@ -26,5 +26,9 @@ double binomial_coefficient_large(int n, int k){
 }
 
 double binom_pmf(int n, int k, double p) {
-    return binomial_coefficient_large(n, k) * pow(p, k) * pow(1-p, n-k);
+    return binomial_coefficient_large(n, k) * pow(p, k) * pow(1 - p, n - k);
+}
+
+double log_binom_pmf(int n, int k, double p) {
+    return std::log(binomial_coefficient_large(n, k)) + k * std::log(p) + (n - k) * std::log(1 - p);
 }

--- a/src/binomial.h
+++ b/src/binomial.h
@@ -12,4 +12,6 @@ double binomial_coefficient_large(int n, int k);
 
 double binom_pmf(int n, int k, double p);
 
+double log_binom_pmf(int n, int k, double p);
+
 # endif // BINOMIAL_H

--- a/src/multinomial.cpp
+++ b/src/multinomial.cpp
@@ -42,3 +42,19 @@ double multinom_pmf(std::vector<uint32_t>& n, std::vector<double>& p) {
         result *= p[i];
     return result;
 }
+
+double log_multinom_pmf(std::vector<uint32_t>& n, std::vector<double>& p) {
+    if (n.size() != p.size())
+        return 0;       // size of n and p must be identical
+    double sum = p[0];
+    for (uint32_t i = 1; i < p.size(); i++)
+        sum += p[i];
+    if (sum != 1.0)
+        return 0;       // sum of p must be one for valid input
+    if (n.size() == 2)
+        return log_binom_pmf(n[0] + n[1], n[0], p[0]);  // faster for binomial case
+    double result = std::log(multinomial_coefficient(n));
+    for (uint32_t i = 0; i < p.size(); i++)
+        result += std::log(p[i]);
+    return result;
+}

--- a/src/multinomial.h
+++ b/src/multinomial.h
@@ -13,4 +13,6 @@ double multinomial_coefficient(std::vector<uint32_t>& n);
 
 double multinom_pmf(std::vector<uint32_t>& n, std::vector<double>& p);
 
+double log_multinom_pmf(std::vector<uint32_t>& n, std::vector<double>& p);
+
 # endif // MULTINOMIAL_H

--- a/src/polyphase/haplothreader.cpp
+++ b/src/polyphase/haplothreader.cpp
@@ -258,7 +258,7 @@ ThreadScore HaploThreader::getCoverageCost(ClusterTuple tuple,
                                      const std::vector<uint32_t>& clusterCoverage
                                     ) const {
     // tuple contains local cluster ids, which have to be translated with covMap to get the global ids
-    double llh = 1.0;
+    double llh = 0.0;
     uint32_t unthreadedReads = 0;
     
     std::vector<uint32_t> clustMult(clusterCoverage.size(), 0);
@@ -271,14 +271,14 @@ ThreadScore HaploThreader::getCoverageCost(ClusterTuple tuple,
         if (clustMult[cid] == 0) {
             unthreadedReads += clusterCoverage[cid];
         } else {
-            double p = (0.975*clustMult[cid])/ploidy;
-            llh *= binom_pmf(coverage, clusterCoverage[cid], p);
+            double p = (0.975 * clustMult[cid])/ploidy;
+            llh += log_binom_pmf(coverage, clusterCoverage[cid], p);
         }
     }
     
-    llh *= binom_pmf(coverage, unthreadedReads, 0.025);
+    llh += log_binom_pmf(coverage, unthreadedReads, 0.025);
 
-    return -std::log(llh);
+    return -llh;
 }
 
 ThreadScore HaploThreader::getSwitchCostAllPerms(const std::vector<GlobalClusterId>& prevTuple, const std::vector<GlobalClusterId>& curTuple) const {

--- a/src/polyphase/readscoring.h
+++ b/src/polyphase/readscoring.h
@@ -1,7 +1,6 @@
 #ifndef READSCORING_H
 #define READSCORING_H
 
-#include <cstdint>
 #include "../readset.h"
 #include "../read.h"
 #include "../genotype.h"
@@ -44,12 +43,10 @@ private:
      * @param alleleDepths The allele depths to base the calculation on
      * @param ploidy Ploidy of the genotypes
      * @param err Allele error rate, which should be assumed
-     * @param normalize If true, the likelihoods are normalized, such that they sum up to 1
      */
     std::unordered_map<Genotype, double> computeGenotypeLikelihoods (std::vector<uint32_t> alleleDepths,
                                                                      const uint32_t ploidy,
-                                                                     const double err,
-                                                                     const bool normalize) const;
+                                                                     const double err) const;
 
     /**
      * For genotype and each pair of alleles, computes the likelihood to observe this exact allele pair under this exact genotype, under the


### PR DESCRIPTION
These changes fix some numeric instability in the polyphase module, where are high coverage caused some likelihood calculations to underflow to zero. The calculations were mostly moved to the log-space, with additional fallbacks for sums over likelihoods (since in log-space they can only be multiplied).