### PR TITLE
support of supplementary alignments in phase

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 Changes
 =======
 
+unreleased
+-----------------
+
+* :issue:`516`: Added ``--use-supplementary`` option to ``phase``. Use this to use supplementary
+  alignments for phasing (previously, supplementary alignments would be ignored).
+  Contributed by @nkkarpov.
+
 v2.2 (2024-01-26)
 -----------------
 

--- a/tests/test_read_grouping.py
+++ b/tests/test_read_grouping.py
@@ -1,0 +1,91 @@
+from whatshap.core import Read
+from whatshap.variants import ReadSetReader as Reader, AlignedRead
+
+
+def test_supplementary_alignment():
+    r = Read("S1", 60, 0, 0, 10, "")
+    r.add_variant(10, 0, 60)
+    ret = Reader.create_read_from_group([AlignedRead(r, True, False, 10, 20)], 10)
+    assert ret is None
+
+
+def test_primary_alignment():
+    r = Read("P1", 60, 0, 0, 10)
+    r.add_variant(10, 0, 60)
+    ret = Reader.create_read_from_group([AlignedRead(r, False, False, 10, 20)], 10)
+    assert len(ret) == 1
+
+
+def test_two_primary_alignment():
+    r1 = Read("P1", 60, 0, 0, 10)
+    r1.add_variant(10, 0, 60)
+    r2 = Read("P1", 60, 0, 0, 10)
+    r2.add_variant(15, 1, 60)
+    ret = Reader.create_read_from_group(
+        [AlignedRead(r1, False, False, 10, 20), AlignedRead(r2, False, False, 10, 20)],
+        distance_threshold=10,
+    )
+    assert len(ret) == 2
+
+
+def test_three_primary_alignment():
+    r1 = Read("P1", 60, 0, 0, 10)
+    r1.add_variant(10, 0, 60)
+    r2 = Read("P1", 60, 0, 0, 10)
+    r2.add_variant(15, 1, 60)
+    r3 = Read("P1", 60, 0, 0, 10)
+    r3.add_variant(20, 1, 60)
+    ret = Reader.create_read_from_group(
+        [
+            AlignedRead(r1, False, False, 10, 30),
+            AlignedRead(r2, False, False, 10, 30),
+            AlignedRead(r3, False, False, 10, 30),
+        ],
+        distance_threshold=10,
+    )
+    assert ret is None
+
+
+def test_two_alignments_same_orientation():
+    primary = Read("P1", 60, 0, 0, 10)
+    primary.add_variant(10, 0, 60)
+    supplementary = Read("S1", 60, 0, 0, 10)
+    supplementary.add_variant(10, 0, 60)
+    supplementary.add_variant(20, 0, 60)
+    ret = Reader.create_read_from_group(
+        [AlignedRead(primary, False, True, 10, 20), AlignedRead(supplementary, True, True, 10, 30)],
+        100,
+    )
+    assert len(ret) == 2
+
+
+def test_two_alignments_different_orientation():
+    primary = Read("P1", 60, 0, 0, 10)
+    primary.add_variant(10, 0, 60)
+    supplementary = Read("S1", 60, 0, 0, 10)
+    supplementary.add_variant(10, 0, 60)
+    supplementary.add_variant(20, 0, 60)
+    ret = Reader.create_read_from_group(
+        [
+            AlignedRead(primary, False, True, 10, 20),
+            AlignedRead(supplementary, True, False, 10, 30),
+        ],
+        100,
+    )
+    assert len(ret) == 1
+
+
+def test_distance():
+    primary = Read("P1", 60, 0, 0, 10)
+    primary.add_variant(10, 0, 60)
+    supplementary = Read("S1", 60, 0, 0, 10)
+    supplementary.add_variant(10, 0, 60)
+    supplementary.add_variant(20, 0, 60)
+    ret = Reader.create_read_from_group(
+        [
+            AlignedRead(primary, False, True, 10, 11),
+            AlignedRead(supplementary, True, True, 20, 30),
+        ],
+        5,
+    )
+    assert len(ret) == 1

--- a/whatshap/cli/phase.py
+++ b/whatshap/cli/phase.py
@@ -311,6 +311,8 @@ def run_whatshap(
     default_gq: int = 30,
     write_command_line_header: bool = True,
     use_ped_samples: bool = False,
+    use_supplementary: bool = False,
+    supplementary_distance_threshold: int = 100_000,
     algorithm: str = "whatshap",
 ) -> None:
     """
@@ -329,6 +331,9 @@ def run_whatshap(
     read_merging_max_error_rate -- max error rate on edge of merge graph considered
     read_merging_positive_threshold -- threshold on the ratio of the two probabilities
     read_merging_negative_threshold -- threshold on the opposite ratio of positive threshold
+    use_supplementary -- use supplementary alignments with primary
+    supplementary_distance_threshold -- distance threshold for filtering supplementary alignments
+
     max_coverage
     distrust_genotypes
     include_homozygous
@@ -347,7 +352,6 @@ def run_whatshap(
         raise CommandLineError("The hapchat algorithm cannot do pedigree phasing")
     if samples is None:
         samples = []
-
     timers = StageTimer()
     logger.info(f"This is WhatsHap {__version__} running under Python {platform.python_version()}")
     numeric_sample_ids = NumericSampleIds()
@@ -378,6 +382,8 @@ def run_whatshap(
                 ignore_read_groups,
                 mapq_threshold=mapping_quality,
                 only_snvs=only_snvs,
+                use_supplementary=use_supplementary,
+                supplementary_distance_threshold=supplementary_distance_threshold,
             )
         )
         show_phase_vcfs = phased_input_reader.has_vcfs
@@ -1140,6 +1146,12 @@ def add_arguments(parser):
     arg("--use-ped-samples", dest="use_ped_samples",
         action="store_true", default=False,
         help="Only work on samples mentioned in the provided PED file.")
+    arg("--use-supplementary", dest="use_supplementary", action="store_true", default=False,
+        help="Use also supplementary alignments (default: ignore supplementary_ alignments)")
+    arg("--supplementary-distance", metavar="DIST", dest="supplementary_distance_threshold", default=100_000,
+        help="Skip supplementary alignments further than DIST bp away from the primary alignment (default: %(default)s)")
+
+
 # fmt: on
 
 


### PR DESCRIPTION
Adding support for supplementary alignments from issue https://github.com/whatshap/whatshap/issues/516 with flag --use-supplementary.

The supplementary alignment must have the same orientation as the primary and be within a distance of at most 100,000 from the primary alignment. This distance parameter can be adjusted using the --supplementary-distance option. The alignments may intersect. To form the new read from the alignments, the algorithm selects only positions where alignments fully agree with the allele of the variant and uses this allele.