### PR TITLE
Add support of multi-allelic variants into haplotagphase

### DIFF
--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -1208,3 +1208,6 @@ It assigns phase information to a variant if the majority of reads containing th
 
 ``--only-indels``
     Assigns information only to indel events.
+
+``--no-mav``
+    Ignore multiallelic variants.

--- a/tests/data/pacbio/variants.vcf
+++ b/tests/data/pacbio/variants.vcf
@@ -16,9 +16,9 @@
 ##FORMAT=<ID=QA,Number=A,Type=Integer,Description="Sum of quality of the alternate observations">
 ##FORMAT=<ID=MIN,Number=1,Type=Integer,Description="Minimum depth in gVCF output block.">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG004_250bp_All
-ref	10854	.	A	G	662.276	.	.	GT	0/1
+ref	10854	.	C	A,G	662.276	.	.	GT	1/2
 ref	11221	.	G	A	0.0010674	.	.	GT	0/1
-ref	11254	.	G	C	448.263	.	.	GT	0/1
+ref	11254	.	A	C,G	448.263	.	.	GT	1/2
 ref	11752	.	C	T	497.72	.	.	GT	0/1
 ref	11805	.	C	T	458.925	.	.	GT	0/1
 ref	11821	.	A	G	437.94	.	.	GT	0/1

--- a/tests/data/pacbio/variants_haplotagphase.vcf
+++ b/tests/data/pacbio/variants_haplotagphase.vcf
@@ -16,9 +16,9 @@
 ##FORMAT=<ID=QA,Number=A,Type=Integer,Description="Sum of quality of the alternate observations">
 ##FORMAT=<ID=MIN,Number=1,Type=Integer,Description="Minimum depth in gVCF output block.">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG004_250bp_All
-ref	10854	.	A	G	662.276	.	.	GT	0/1
-ref	11221	.	G	A	0.0010674	.	.	GT	0/1
-ref	11254	.	G	C	448.263	.	.	GT	0/1
+ref	10854	.	T	A,C	662.276	.	.	GT	1/2
+ref	11221	.	C	A	0.0010674	.	.	GT	0/1
+ref	11254	.	T	G,C	448.263	.	.	GT	1/2
 ref	11752	.	C	T	497.72	.	.	GT	0/1
 ref	11805	.	C	T	458.925	.	.	GT	0/1
 ref	11821	.	A	G	437.94	.	.	GT	0/1

--- a/tests/test_run_haplotagphase.py
+++ b/tests/test_run_haplotagphase.py
@@ -30,7 +30,7 @@ def test_nomav_haplototagphase(tmpdir):
         alignment_file="tests/data/pacbio/haplotagged.bam",
         reference="tests/data/pacbio/reference.fasta",
         output=outvcf,
-        ignore_mav=True,
+        mav=False,
     )
     tables = list(VcfReader(outvcf, phases=True, mav=True))
     for table in tables:

--- a/tests/test_run_haplotagphase.py
+++ b/tests/test_run_haplotagphase.py
@@ -50,7 +50,7 @@ def test_compute_votes():
     votes = compute_votes(
         {1: False, 2: False, 3: True},
         [a, b, c],
-        al2id={
+        allele_to_id={
             1: {0: 0, 1: 1},
             2: {0: 0, 1: 1},
             3: {0: 0, 1: 1},

--- a/tests/test_run_haplotagphase.py
+++ b/tests/test_run_haplotagphase.py
@@ -16,14 +16,14 @@ def test_haplotagphase(tmpdir):
         reference="tests/data/pacbio/reference.fasta",
         output=outvcf,
     )
-    tables = list(VcfReader(outvcf, phases=True))
+    tables = list(VcfReader(outvcf, phases=True, mav=True))
     for table in tables:
         assert len(table.phases) == 1
         n_unphased = sum(1 for phase in table.phases[0] if phase is None)
         assert n_unphased == 4
 
 
-def test_hapltotagphase(tmpdir):
+def test_nomav_hapltotagphase(tmpdir):
     outvcf = tmpdir.join("output.vcf")
     run_haplotagphase(
         variant_file="tests/data/pacbio/variants_haplotagphase.vcf",
@@ -32,9 +32,10 @@ def test_hapltotagphase(tmpdir):
         output=outvcf,
         ignore_mav=True,
     )
-    tables = list(VcfReader(outvcf, phases=True))
+    tables = list(VcfReader(outvcf, phases=True, mav=True))
     for table in tables:
         assert len(table.phases) == 1
+        print([phase for phase in table.phases[0]])
         n_unphased = sum(1 for phase in table.phases[0] if phase is None)
         assert n_unphased == 6
 

--- a/tests/test_run_haplotagphase.py
+++ b/tests/test_run_haplotagphase.py
@@ -11,7 +11,7 @@ from whatshap.vcf import VcfReader
 def test_haplotagphase(tmpdir):
     outvcf = tmpdir.join("output.vcf")
     run_haplotagphase(
-        variant_file="tests/data/pacbio/variants.vcf",
+        variant_file="tests/data/pacbio/variants_haplotagphase.vcf",
         alignment_file="tests/data/pacbio/haplotagged.bam",
         reference="tests/data/pacbio/reference.fasta",
         output=outvcf,

--- a/tests/test_run_haplotagphase.py
+++ b/tests/test_run_haplotagphase.py
@@ -47,5 +47,13 @@ def test_compute_votes():
         1: {(0, 0): 50, (0, 1): 0, (1, 1): 20, (1, 0): 0},
         2: {(0, 0): 10, (0, 1): 30},
     }
-    votes = compute_votes({1: False, 2: False, 3: True}, [a, b, c])
+    votes = compute_votes(
+        {1: False, 2: False, 3: True},
+        [a, b, c],
+        al2id={
+            1: {0: 0, 1: 1},
+            2: {0: 0, 1: 1},
+            3: {0: 0, 1: 1},
+        },
+    )
     assert votes == expected_votes

--- a/tests/test_run_haplotagphase.py
+++ b/tests/test_run_haplotagphase.py
@@ -23,7 +23,7 @@ def test_haplotagphase(tmpdir):
         assert n_unphased == 4
 
 
-def test_nomav_hapltotagphase(tmpdir):
+def test_nomav_haplototagphase(tmpdir):
     outvcf = tmpdir.join("output.vcf")
     run_haplotagphase(
         variant_file="tests/data/pacbio/variants_haplotagphase.vcf",

--- a/tests/test_run_haplotagphase.py
+++ b/tests/test_run_haplotagphase.py
@@ -23,6 +23,22 @@ def test_haplotagphase(tmpdir):
         assert n_unphased <= 4
 
 
+def test_hapltotagphase(tmpdir):
+    outvcf = tmpdir.join("output.vcf")
+    run_haplotagphase(
+        variant_file="tests/data/pacbio/variants_haplotagphase.vcf",
+        alignment_file="tests/data/pacbio/haplotagged.bam",
+        reference="tests/data/pacbio/reference.fasta",
+        output=outvcf,
+        ignore_mav=True,
+    )
+    tables = list(VcfReader(outvcf, phases=True))
+    for table in tables:
+        assert len(table.phases) == 1
+        n_unphased = sum(1 for phase in table.phases[0] if phase is None)
+        assert n_unphased <= 6
+
+
 def test_compute_votes():
     a = Read("a", 60, 0, 0, 0, "", 1, 1)
     a.add_variant(1, 0, 30)

--- a/tests/test_run_haplotagphase.py
+++ b/tests/test_run_haplotagphase.py
@@ -20,7 +20,7 @@ def test_haplotagphase(tmpdir):
     for table in tables:
         assert len(table.phases) == 1
         n_unphased = sum(1 for phase in table.phases[0] if phase is None)
-        assert n_unphased <= 4
+        assert n_unphased == 4
 
 
 def test_hapltotagphase(tmpdir):
@@ -36,7 +36,7 @@ def test_hapltotagphase(tmpdir):
     for table in tables:
         assert len(table.phases) == 1
         n_unphased = sum(1 for phase in table.phases[0] if phase is None)
-        assert n_unphased <= 6
+        assert n_unphased == 6
 
 
 def test_compute_votes():

--- a/whatshap/cli/__init__.py
+++ b/whatshap/cli/__init__.py
@@ -136,7 +136,7 @@ class PhasedInputReader:
         *,
         read_vcf=True,
         regions=None,
-        predicted_genotypes: Optional[List[Genotype]] = None,
+        restricted_genotypes: Optional[List[Genotype]] = None,
     ):
         """
         Return a pair (readset, vcf_source_ids) where readset is a sorted ReadSet.
@@ -160,7 +160,7 @@ class PhasedInputReader:
         bam_sample = None if self._ignore_read_groups else sample
         try:
             readset = readset_reader.read(
-                chromosome, variants, bam_sample, reference, regions, predicted_genotypes
+                chromosome, variants, bam_sample, reference, regions, restricted_genotypes
             )
         except SampleNotFoundError:
             logger.warning("Sample %r not found in any BAM/CRAM file.", bam_sample)

--- a/whatshap/cli/__init__.py
+++ b/whatshap/cli/__init__.py
@@ -127,7 +127,9 @@ class PhasedInputReader:
                 m[variant_table.chromosome] = variant_table
             self._vcfs.append(m)
 
-    def read(self, chromosome, variants, sample, *, read_vcf=True, regions=None, genotypes=None):
+    def read(
+        self, chromosome, variants, sample, *, read_vcf=True, regions=None, valid_alleles=None
+    ):
         """
         Return a pair (readset, vcf_source_ids) where readset is a sorted ReadSet.
 
@@ -150,7 +152,7 @@ class PhasedInputReader:
         bam_sample = None if self._ignore_read_groups else sample
         try:
             readset = readset_reader.read(
-                chromosome, variants, bam_sample, reference, regions, genotypes
+                chromosome, variants, bam_sample, reference, regions, valid_alleles
             )
         except SampleNotFoundError:
             logger.warning("Sample %r not found in any BAM/CRAM file.", bam_sample)

--- a/whatshap/cli/__init__.py
+++ b/whatshap/cli/__init__.py
@@ -136,7 +136,7 @@ class PhasedInputReader:
         *,
         read_vcf=True,
         regions=None,
-        allowed_genotypes: Optional[List[Genotype]] = None,
+        predicted_genotypes: Optional[List[Genotype]] = None,
     ):
         """
         Return a pair (readset, vcf_source_ids) where readset is a sorted ReadSet.
@@ -160,7 +160,7 @@ class PhasedInputReader:
         bam_sample = None if self._ignore_read_groups else sample
         try:
             readset = readset_reader.read(
-                chromosome, variants, bam_sample, reference, regions, allowed_genotypes
+                chromosome, variants, bam_sample, reference, regions, predicted_genotypes
             )
         except SampleNotFoundError:
             logger.warning("Sample %r not found in any BAM/CRAM file.", bam_sample)

--- a/whatshap/cli/__init__.py
+++ b/whatshap/cli/__init__.py
@@ -127,7 +127,7 @@ class PhasedInputReader:
                 m[variant_table.chromosome] = variant_table
             self._vcfs.append(m)
 
-    def read(self, chromosome, variants, sample, *, read_vcf=True, regions=None):
+    def read(self, chromosome, variants, sample, *, read_vcf=True, regions=None, genotypes=None):
         """
         Return a pair (readset, vcf_source_ids) where readset is a sorted ReadSet.
 
@@ -149,7 +149,9 @@ class PhasedInputReader:
             )
         bam_sample = None if self._ignore_read_groups else sample
         try:
-            readset = readset_reader.read(chromosome, variants, bam_sample, reference, regions)
+            readset = readset_reader.read(
+                chromosome, variants, bam_sample, reference, regions, genotypes
+            )
         except SampleNotFoundError:
             logger.warning("Sample %r not found in any BAM/CRAM file.", bam_sample)
             readset = ReadSet()

--- a/whatshap/cli/__init__.py
+++ b/whatshap/cli/__init__.py
@@ -1,6 +1,7 @@
 import sys
 import resource
 import logging
+from typing import List, Optional
 
 from whatshap.bam import (
     AlignmentFileNotIndexedError,
@@ -10,7 +11,7 @@ from whatshap.bam import (
 )
 from whatshap.variants import ReadSetReader, ReadSetError
 from whatshap.utils import IndexedFasta, FastaNotIndexedError, detect_file_format
-from whatshap.core import ReadSet
+from whatshap.core import Genotype, ReadSet
 from whatshap.vcf import VcfReader
 
 logger = logging.getLogger(__name__)
@@ -128,7 +129,14 @@ class PhasedInputReader:
             self._vcfs.append(m)
 
     def read(
-        self, chromosome, variants, sample, *, read_vcf=True, regions=None, valid_alleles=None
+        self,
+        chromosome,
+        variants,
+        sample,
+        *,
+        read_vcf=True,
+        regions=None,
+        allowed_genotypes: Optional[List[Genotype]] = None,
     ):
         """
         Return a pair (readset, vcf_source_ids) where readset is a sorted ReadSet.
@@ -152,7 +160,7 @@ class PhasedInputReader:
         bam_sample = None if self._ignore_read_groups else sample
         try:
             readset = readset_reader.read(
-                chromosome, variants, bam_sample, reference, regions, valid_alleles
+                chromosome, variants, bam_sample, reference, regions, allowed_genotypes
             )
         except SampleNotFoundError:
             logger.warning("Sample %r not found in any BAM/CRAM file.", bam_sample)

--- a/whatshap/cli/haplotagphase.py
+++ b/whatshap/cli/haplotagphase.py
@@ -120,7 +120,7 @@ def run_haplotagphase(
                 genotypes = variant_table.genotypes_of(sample)
                 with timers("read-bam"):
                     reads, _ = phased_input_reader.read(
-                        chromosome, variant_table.variants, sample, valid_alleles=genotypes
+                        chromosome, variant_table.variants, sample, allowed_genotypes=genotypes
                     )
                 phases = variant_table.phases_of(sample)
 

--- a/whatshap/cli/haplotagphase.py
+++ b/whatshap/cli/haplotagphase.py
@@ -61,7 +61,6 @@ def run_haplotagphase(
     ignore_mav: bool = False,
     tag: str = "PS",
 ):
-    logger.debug(f"{ignore_mav = }")
     if reference is None:
         raise CommandLineError("Option --reference should be specified")
     timers = StageTimer()

--- a/whatshap/cli/haplotagphase.py
+++ b/whatshap/cli/haplotagphase.py
@@ -40,7 +40,7 @@ def add_arguments(parser):
     arg("--chromosome", dest="chromosomes", metavar="CHROMOSOME", default=[], action="append",
         help="Name of chromosome to phase. If not given, all chromosomes in the input VCF are phased. "
         "Can be used multiple times.")
-    arg("--no-mav", dest="ignore_mav", default=False, action="store_true", help="Ignore multiallelic variants.")
+    arg("--no-mav", dest="mav", default=True, action="store_false", help="Ignore multiallelic variants.")
     arg("variant_file", metavar="VCF", help="VCF file with variants to phase (must be gzip-compressed and indexed)")
     arg("alignment_file", metavar="ALIGNMENTS",
         help="BAM/CRAM file with alignments tagged by haplotype and phase set")

--- a/whatshap/cli/haplotagphase.py
+++ b/whatshap/cli/haplotagphase.py
@@ -232,7 +232,9 @@ def consensus(
                 if max_length > cut_homopolymers:
                     continue
         super_reads[0].append(Variant(pos, allele=id_to_allele[pos][best_allele], quality=score))
-        super_reads[1].append(Variant(pos, allele=id_to_allele[pos][1 - best_allele], quality=score))
+        super_reads[1].append(
+            Variant(pos, allele=id_to_allele[pos][1 - best_allele], quality=score)
+        )
     for read in super_reads:
         read.sort(key=lambda x: x.position)
     return super_reads, components

--- a/whatshap/cli/haplotagphase.py
+++ b/whatshap/cli/haplotagphase.py
@@ -127,6 +127,7 @@ def run_haplotagphase(
                 homozygous = dict()
                 change = dict()
                 phased = dict()
+                # mapping of detected variants to 0/1 and reversed mappings.
                 allele_to_id = defaultdict(dict)
                 id_to_allele = defaultdict(dict)
                 homozygous_number = 0
@@ -205,7 +206,7 @@ def consensus(
             Variants with `None` are considered unphased.
         votes: A dictionary of variant positions to their votes.
             Each vote includes alleles and their corresponding quality scores.
-        id_to_allele: A dictionary mapping variant and positions to the allele.
+        id_to_allele: A dictionary mapping variant id and positions to the actual allele.
 
     Returns:
         A tuple containing two elements:

--- a/whatshap/cli/haplotagphase.py
+++ b/whatshap/cli/haplotagphase.py
@@ -120,7 +120,7 @@ def run_haplotagphase(
                 genotypes = variant_table.genotypes_of(sample)
                 with timers("read-bam"):
                     reads, _ = phased_input_reader.read(
-                        chromosome, variant_table.variants, sample, allowed_genotypes=genotypes
+                        chromosome, variant_table.variants, sample, predicted_genotypes=genotypes
                     )
                 phases = variant_table.phases_of(sample)
 

--- a/whatshap/cli/haplotagphase.py
+++ b/whatshap/cli/haplotagphase.py
@@ -58,7 +58,7 @@ def run_haplotagphase(
     gap_threshold: int = 70,
     cut_poly: int = 10,
     write_command_line_header: bool = True,
-    ignore_mav: bool = False,
+    mav: bool = True,
     tag: str = "PS",
 ):
     if reference is None:
@@ -87,13 +87,13 @@ def run_haplotagphase(
                     in_path=variant_file,
                     out_file=output,
                     tag=tag,
-                    mav=not ignore_mav,
+                    mav=mav,
                 )
             )
         except (OSError, VcfError) as e:
             raise CommandLineError(e)
 
-        vcf_reader = stack.enter_context(VcfReader(variant_file, phases=True, mav=not ignore_mav))
+        vcf_reader = stack.enter_context(VcfReader(variant_file, phases=True, mav=mav))
 
         if ignore_read_groups and len(vcf_reader.samples) > 1:
             raise CommandLineError(
@@ -120,7 +120,7 @@ def run_haplotagphase(
                 genotypes = variant_table.genotypes_of(sample)
                 with timers("read-bam"):
                     reads, _ = phased_input_reader.read(
-                        chromosome, variant_table.variants, sample, predicted_genotypes=genotypes
+                        chromosome, variant_table.variants, sample, restricted_genotypes=genotypes
                     )
                 phases = variant_table.phases_of(sample)
 

--- a/whatshap/variants.py
+++ b/whatshap/variants.py
@@ -162,7 +162,7 @@ class ReadSetReader:
 
         If reference is None, alleles are detected by inspecting the
         existing alignment (via the CIGAR).
-        
+
         If the valid_alleles is not None, then only alleles from valid_alleles[i] will be considered for variant i.
 
         chromosome -- name of chromosome to work on

--- a/whatshap/variants.py
+++ b/whatshap/variants.py
@@ -156,7 +156,7 @@ class ReadSetReader:
         sample,
         reference,
         regions=None,
-        predicted_genotypes: Optional[List[Genotype]] = None,
+        restricted_genotypes: Optional[List[Genotype]] = None,
     ) -> ReadSet:
         """
         Detect alleles and return a ReadSet object containing reads representing
@@ -169,7 +169,7 @@ class ReadSetReader:
         If reference is None, alleles are detected by inspecting the
         existing alignment (via the CIGAR).
 
-        If the predicted_genotypes is not None, then only alleles from predicted_genotypes[i] will be considered for variant i. The length of predicted_genotypes should match the length of variants.
+        If the restricted_genotypes is not None, then only alleles from restricted_genotypes[i] will be considered for variant i. The length of restricted_genotypes should match the length of variants.
 
         chromosome -- name of chromosome to work on
         variants -- list of vcf.VcfVariant objects
@@ -177,7 +177,7 @@ class ReadSetReader:
             ignored and all reads in the file are used.
         reference -- reference sequence of the given chromosome (or None)
         regions -- list of start,end tuples (end can be None)
-        predicted_genotypes -- list of predicted genotypes (or None if there is no reliable auxiliary information).
+        restricted_genotypes -- list of restricted genotypes (or None if there is no reliable auxiliary information).
         """
         # Since variants are identified by position, positions must be unique.
         if __debug__ and variants:
@@ -185,10 +185,10 @@ class ReadSetReader:
             pos, count = varposc.most_common()[0]
             assert count == 1, f"Position {pos} occurs more than once in variant list."
 
-        assert predicted_genotypes is None or len(predicted_genotypes) == len(variants)
+        assert restricted_genotypes is None or len(restricted_genotypes) == len(variants)
         alignments = self._usable_alignments(chromosome, sample, regions)
         reads = self._alignments_to_reads(
-            alignments, variants, sample, reference, predicted_genotypes
+            alignments, variants, sample, reference, restricted_genotypes
         )
         grouped_reads = self._group_reads(reads, self._supplementary_distance_threshold)
         readset = self._make_readset_from_grouped_reads(grouped_reads)
@@ -318,7 +318,12 @@ class ReadSetReader:
         return self._reader.has_reference(chromosome)
 
     def _alignments_to_reads(
-        self, alignments, variants, sample, reference, predicted_genotypes: Optional[List[Genotype]]
+        self,
+        alignments,
+        variants,
+        sample,
+        reference,
+        restricted_genotypes: Optional[List[Genotype]],
     ):
         """
         Convert BAM alignments to Read objects.
@@ -412,7 +417,7 @@ class ReadSetReader:
                     i += 1
                 detected = self.detect_alleles_by_alignment(
                     variants,
-                    predicted_genotypes,
+                    restricted_genotypes,
                     i,
                     alignment.bam_alignment,
                     reference,
@@ -572,7 +577,7 @@ class ReadSetReader:
     @staticmethod
     def realign(
         variant: VcfVariant,
-        predicted_variants: Optional[Genotype],
+        restricted_variants: Optional[Genotype],
         bam_read: AlignedSegment,
         cigartuples,
         i,
@@ -598,7 +603,7 @@ class ReadSetReader:
         variant position and into a part starting at the variant position, see split_cigar().
 
         variant -- VcfVariant
-        predicted_variants -- genotype with predicted variants (or None if there is no such information)
+        restricted_variants -- genotype with restricted variants (or None if there is no such information)
         bam_read -- the AlignedSegment
         cigartuples -- the AlignedSegment.cigartuples property (accessing it is expensive, so re-use it)
         i, consumed -- see split_cigar method
@@ -714,7 +719,7 @@ class ReadSetReader:
             distances = [
                 (i, edit_distance_affine_gap(query, allele, base_qualities, gap_start, gap_extend))
                 for i, allele in enumerate(padded_alleles)
-                if predicted_variants is None or i in predicted_variants.as_vector()
+                if restricted_variants is None or i in restricted_variants.as_vector()
             ]
             distances.sort(key=lambda x: x[1])
             base_qual_score = (
@@ -724,7 +729,7 @@ class ReadSetReader:
             distances = [
                 (i, edit_distance(query, allele))
                 for i, allele in enumerate(padded_alleles)
-                if predicted_variants is None or i in predicted_variants.as_vector()
+                if restricted_variants is None or i in restricted_variants.as_vector()
             ]
             distances.sort(key=lambda x: x[1])
             base_qual_score = 30
@@ -737,7 +742,7 @@ class ReadSetReader:
     @staticmethod
     def detect_alleles_by_alignment(
         variants: List[VcfVariant],
-        predicted_genotypes: Optional[List[Genotype]],
+        restricted_genotypes: Optional[List[Genotype]],
         j,
         bam_read: AlignedSegment,
         reference,
@@ -774,7 +779,7 @@ class ReadSetReader:
         for index, i, consumed, query_pos in _iterate_cigar(variants, j, bam_read, cigartuples):
             allele, quality = ReadSetReader.realign(
                 variants[index],
-                predicted_genotypes[index] if predicted_genotypes is not None else None,
+                restricted_genotypes[index] if restricted_genotypes else None,
                 bam_read,
                 cigartuples,
                 i,

--- a/whatshap/variants.py
+++ b/whatshap/variants.py
@@ -593,7 +593,7 @@ class ReadSetReader:
         splitted_strings,
     ):
         """
-        Realign a read to the two alleles (or to the valid_alleles if it is not None) of a single variant.
+        Realign a read to the two alleles (or to the alleles from genotype if it is not None) of a single variant.
         i and consumed describe where to split the cigar into a part before the
         variant position and into a part starting at the variant position, see split_cigar().
 

--- a/whatshap/variants.py
+++ b/whatshap/variants.py
@@ -572,7 +572,7 @@ class ReadSetReader:
     @staticmethod
     def realign(
         variant: VcfVariant,
-        genotype: Optional[Genotype],
+        predicted_variants: Optional[Genotype],
         bam_read: AlignedSegment,
         cigartuples,
         i,
@@ -598,7 +598,7 @@ class ReadSetReader:
         variant position and into a part starting at the variant position, see split_cigar().
 
         variant -- VcfVariant
-        genotype -- predicted genotype (or None if there is no such information)
+        predicted_variants -- genotype with predicted variants (or None if there is no such information)
         bam_read -- the AlignedSegment
         cigartuples -- the AlignedSegment.cigartuples property (accessing it is expensive, so re-use it)
         i, consumed -- see split_cigar method
@@ -714,7 +714,7 @@ class ReadSetReader:
             distances = [
                 (i, edit_distance_affine_gap(query, allele, base_qualities, gap_start, gap_extend))
                 for i, allele in enumerate(padded_alleles)
-                if genotype is None or i in genotype.as_vector()
+                if predicted_variants is None or i in predicted_variants.as_vector()
             ]
             distances.sort(key=lambda x: x[1])
             base_qual_score = (
@@ -724,7 +724,7 @@ class ReadSetReader:
             distances = [
                 (i, edit_distance(query, allele))
                 for i, allele in enumerate(padded_alleles)
-                if genotype is None or i in genotype.as_vector()
+                if predicted_variants is None or i in predicted_variants.as_vector()
             ]
             distances.sort(key=lambda x: x[1])
             base_qual_score = 30

--- a/whatshap/variants.py
+++ b/whatshap/variants.py
@@ -162,6 +162,8 @@ class ReadSetReader:
 
         If reference is None, alleles are detected by inspecting the
         existing alignment (via the CIGAR).
+        
+        If the valid_alleles is not None, then only alleles from valid_alleles[i] will be considered for variant i.
 
         chromosome -- name of chromosome to work on
         variants -- list of vcf.VcfVariant objects
@@ -169,7 +171,7 @@ class ReadSetReader:
             ignored and all reads in the file are used.
         reference -- reference sequence of the given chromosome (or None)
         regions -- list of start,end tuples (end can be None)
-        valid_alleles -- list of valid_alleles (or None if not available).
+        valid_alleles -- list of valid_alleles (or None if there is no reliable auxiliary information).
         """
         # Since variants are identified by position, positions must be unique.
         if __debug__ and variants:
@@ -580,12 +582,12 @@ class ReadSetReader:
         splitted_strings,
     ):
         """
-        Realign a read to the two alleles of a single variant.
+        Realign a read to the two alleles (or to the valid_alleles if it is not None) of a single variant.
         i and consumed describe where to split the cigar into a part before the
         variant position and into a part starting at the variant position, see split_cigar().
 
         variant -- VcfVariant
-        genotype -- Genotype
+        valid_alleles -- list of valid alleles
         bam_read -- the AlignedSegment
         cigartuples -- the AlignedSegment.cigartuples property (accessing it is expensive, so re-use it)
         i, consumed -- see split_cigar method


### PR DESCRIPTION
Sometimes we can have two non-reference alleles. Previously, there was no way to support them because the phase and haplotagphase commands didn't support multi-allelic variants. I need to ensure that I choose alleles only from the list provided by the GT tag. It requires small changes in the logic around allele detection. 