### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,47 @@
+Contributing
+============
+
+Contributions to WhatsHap are welcome! Some ways in which you can help are,
+for example:
+
+* Fixing a bug
+* Adding new feature
+* Improving the documentation
+* Responding to issues on GitHub
+* Reviewing a pull request
+
+For changes affecting the source code, it is easiest to send in a pull request
+(PR) on GitHub.
+Here are some guidelines for how to do this. They are not strict rules.
+When in doubt, send in a PR and we will sort it out.
+
+* Limit a PR to a single topic. Submit multiple PRs if necessary. This way, it
+  is easier to discuss the changes individually, and in case we find that one
+  of them should not go in, the others can still be accepted.
+* For larger changes, consider opening an issue first to plan what you want to
+  do.
+* Include appropriate unit or integration tests. Sometimes, tests are hard to
+  write or don’t make sense. If you think this is the case, just leave the tests
+  out initially and we can discuss whether to add any.
+* Add documentation and a changelog entry if appropriate.
+
+
+Code style
+----------
+
+* The source code (``.py`` files only) needs to be formatted with
+  `black <https://black.readthedocs.io/>`__.
+  If you install `pre-commit <https://pre-commit.com>`__,
+  the formatting will be done for you.
+* There are inconsistencies in the current code base since it’s a few years old
+  already. New code should follow the current rules, however.
+* Using an IDE is beneficial (PyCharm, for example). It helps to catch lots of
+  style issues early (unused imports, spacing etc.).
+* Use `Google-style docstrings <https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html>`_
+  (this is not PyCharm’s default setting).
+* Avoid unnecessary abbreviations for variable names.
+  Code is more often read than written.
+* When writing a help text for a new command-line option,
+  look at the existing ``--help`` output and follow the style.
+  Try to make it look nice and short.
+  Complete documentation should be in the online guide.

--- a/doc/develop.rst
+++ b/doc/develop.rst
@@ -1,5 +1,10 @@
-Developing
-==========
+.. include:: ../CONTRIBUTING.rst
+
+
+.. _developing:
+
+Developing WhatsHap
+-------------------
 
 The `WhatsHap source code is on GitHub <https://github.com/whatshap/whatshap/>`_.
 WhatsHap is developed in Python 3, Cython and C++.
@@ -22,7 +27,7 @@ GitHub account)::
 The last command installs also all the development dependencies.
 Omit the ``[dev]`` to leave them out.
 
-Install also `pre-commit <https://pre-commit.com/>`_ and run ``pre-commit install``.
+Install also `pre-commit <https://pre-commit.com/>`__ and run ``pre-commit install``.
 
 
 Development installation when using Conda
@@ -64,9 +69,9 @@ See one way below for how to install them on Ubuntu.
 Code style
 ----------
 
-Python code needs to be formatted with `Black <https://github.com/psf/black>`_.
+Python code needs to be formatted with `Black <https://github.com/psf/black>`__.
 Either run ``black whatshap tests`` manually before you commit or use the
-`pre-commit <https://pre-commit.com/>`_ framework to automate this.
+`pre-commit <https://pre-commit.com/>`__ framework to automate this.
 
 To check other style issues, run ::
 
@@ -158,7 +163,7 @@ and is translated by `Sphinx <http://www.sphinx-doc.org/>`_ into HTML format.
 
 Documentation is hosted on `Read the Docs <https://readthedocs.org/>`_.
 It is built automatically whenever a commit is made. The documentation in the
-``master`` branch should be visible at
+``main`` branch should be visible at
 `https://whatshap.readthedocs.io/en/latest/ <https://whatshap.readthedocs.io/en/latest/>`_
 and documentation for the most recent released version should be visible at
 `https://whatshap.readthedocs.io/en/stable/ <https://whatshap.readthedocs.io/en/stable/>`_.


### PR DESCRIPTION
Prompted by PR #546. I copied this from [Cutadapt’s Contributing guide](https://cutadapt.readthedocs.io/en/stable/develop.html#contributing) and adjusted it a little bit.