### PR TITLE
Faster realignment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ development version
 
 * :issue:`537`: Fixed a crash when running `haplotag` on CRAM files.
 * Start supporting Python 3.13
+* Reduced processing time of BAM files by about 33% when using realignment.
 
 v2.3 (2024-05-05)
 -----------------


### PR DESCRIPTION
I found a performance hazard in the `realign` routine: For every read alignment and every variant, the list of cigar operations needs to be split at the variant positions. This is necessary to obtain the intervals on the read and reference sequences for the actual realignment (= edit distance calculation). In the current implementation, the split function always creates a full copy of the cigar list, even though only a very small fraction of it is actually used for each realignment. This has been resolved by computing two iterators for the left and right split that lazily read from the full list.

This improvement saves about 1/3 of the total BAM processing time. For testing I used on one of the `polyphase` instances from my thesis (80X simulated reads from chr1 of two human samples, squashed into a tetraploid sample):

Before:
```
== SUMMARY ==
Maximum memory usage: 2.257 GB
Time spent reading BAM/CRAM:          674.3 s
Time spent parsing VCF:                 2.5 s
Time spent detecting blocks:            3.2 s
Time spent scoring reads:              39.7 s
Time spent solving cluster editing:   246.6 s
Time spent threading haplotypes:       17.2 s
Time spent reordering haplotypes:       3.2 s
Time spent writing VCF:                 2.7 s
Time spent on rest:                    11.1 s
Total elapsed time:                  1000.5 s
```

After:
```
== SUMMARY ==
Maximum memory usage: 2.257 GB
Time spent reading BAM/CRAM:          449.9 s
Time spent parsing VCF:                 2.5 s
Time spent detecting blocks:            3.2 s
Time spent scoring reads:              39.5 s
Time spent solving cluster editing:   247.4 s
Time spent threading haplotypes:       17.2 s
Time spent reordering haplotypes:       3.2 s
Time spent writing VCF:                 2.7 s
Time spent on rest:                    11.2 s
Total elapsed time:                   776.9 s
```

It feels like the processing should still be a lot faster but the remaining processing time is spread out over very different routines: I estimate that about 1/4 go the edit distance computation, 1/4 to the `cigartuples` method from `pysam`, 1/8 to the `_iterate_cigar` and the rest to the sorrounding Python code.