### PR TITLE
Nicer message when reference compressed with gzip instead of bgzip

### DIFF
--- a/whatshap/cli/__init__.py
+++ b/whatshap/cli/__init__.py
@@ -114,6 +114,18 @@ class PhasedInputReader:
                 "could not be found. Please create one with "
                 "'samtools faidx'."
             )
+        contig_names = list(indexed_fasta.keys())
+        if contig_names:
+            try:
+                indexed_fasta[contig_names[-1]][:1]
+            except ValueError as e:
+                if e.args[0].startswith("A BGZF (e.g. a BAM file) block should start with"):
+                    raise CommandLineError(
+                        "Error while opening compressed FASTA reference file: "
+                        "The file appears to have been compressed with gzip instead of bgzip. "
+                    )
+                else:
+                    raise
         return indexed_fasta
 
     def read_vcfs(self):

--- a/whatshap/utils.py
+++ b/whatshap/utils.py
@@ -54,7 +54,7 @@ def stdout_is_regular_file() -> bool:
     return stat.S_ISREG(mode)
 
 
-def IndexedFasta(path):
+def IndexedFasta(path) -> pyfaidx.Fasta:
     try:
         f = pyfaidx.Fasta(path, as_raw=True, sequence_always_upper=True, build_index=False)
     except pyfaidx.IndexNotFoundError:


### PR DESCRIPTION
This avoids the confusing error message when opening a gzip-compressed FASTA reference, which mentions "e.g. a BAM file" and therefore incorrectly leads the user to think that something is wrong with the BAM inputs.

Closes #534