### PR TITLE
Fix tests on macOS

### DIFF
--- a/tests/test_genotyping.py
+++ b/tests/test_genotyping.py
@@ -13,13 +13,24 @@ from whatshap.testhelpers import (
 )
 
 
+def likelihoods_equal(a: PhredGenotypeLikelihoods, b: PhredGenotypeLikelihoods):
+    for gt in a.genotypes():
+        if not math.isclose(a[gt], b[gt]):
+            return False
+    return True
+
+
 def compare_to_expected(dp_forward_backward, positions, expected=None, genotypes=None):
     # check if computed likelihoods are equal to expected ones (if given)
     if expected is not None:
         for i in range(len(positions)):
             likelihoods = dp_forward_backward.get_genotype_likelihoods("individual0", i)
-            print(likelihoods, expected[i], i)
-            assert likelihoods == expected[i]
+            print(f"Position {i}:")
+            print(f"Computed likelihoods: {likelihoods}")
+            print(f"Expected likelihoods: {expected[i]}")
+            assert likelihoods_equal(
+                likelihoods, expected[i]
+            ), f"Likelihood mismatch at position {i}: Expected {expected[i]} but got {likelihoods}"
 
     # check if likeliest genotype is equal to expected genotype
     for i in range(len(positions)):
@@ -39,7 +50,9 @@ def compare_to_expected(dp_forward_backward, positions, expected=None, genotypes
         )
 
         if genotypes is not None:
-            assert max_geno == genotypes[i]
+            assert (
+                max_geno == genotypes[i]
+            ), f"Mismatch at position {i}: {max_geno} != {genotypes[i]}"
 
 
 def test_genotyping_empty_readset():

--- a/tests/test_genotyping.py
+++ b/tests/test_genotyping.py
@@ -10,14 +10,8 @@ from whatshap.testhelpers import (
     string_to_readset,
     canonic_index_to_biallelic_gt,
     canonic_index_list_to_biallelic_gt_list,
+    likelihoods_equal,
 )
-
-
-def likelihoods_equal(a: PhredGenotypeLikelihoods, b: PhredGenotypeLikelihoods):
-    for gt in a.genotypes():
-        if not math.isclose(a[gt], b[gt], abs_tol=1e-9):
-            return False
-    return True
 
 
 def compare_to_expected(dp_forward_backward, positions, expected=None, genotypes=None):

--- a/tests/test_genotyping.py
+++ b/tests/test_genotyping.py
@@ -15,7 +15,7 @@ from whatshap.testhelpers import (
 
 def likelihoods_equal(a: PhredGenotypeLikelihoods, b: PhredGenotypeLikelihoods):
     for gt in a.genotypes():
-        if not math.isclose(a[gt], b[gt]):
+        if not math.isclose(a[gt], b[gt], abs_tol=1e-9):
             return False
     return True
 
@@ -399,7 +399,7 @@ def test_weighted_genotyping2():
         PhredGenotypeLikelihoods([1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]),
         PhredGenotypeLikelihoods([0, 1, 0]),
     ]
-    check_genotyping_single_individual(reads, weights, expected_likelihoods, None, 100)
+    check_genotyping_single_individual(reads, weights, expected_likelihoods, None, 50)
 
 
 def test_weighted_genotyping3():
@@ -416,7 +416,7 @@ def test_weighted_genotyping3():
         PhredGenotypeLikelihoods([0, 1.0 / 3.0, 2.0 / 3.0]),
         PhredGenotypeLikelihoods([0, 1, 0]),
     ]
-    check_genotyping_single_individual(reads, weights, expected_likelihoods, None, 500)
+    check_genotyping_single_individual(reads, weights, expected_likelihoods, None, 300)
 
 
 def test_weighted_genotyping4():
@@ -503,7 +503,7 @@ def test_weighted_genotyping6():
         PhredGenotypeLikelihoods([0, 1, 0]),
     ]
     check_genotyping_single_individual(
-        reads, weights, expected_likelihoods, None, 1000, genotype_priors
+        reads, weights, expected_likelihoods, None, 100, genotype_priors
     )
 
 

--- a/tests/test_pedigreegenotyping.py
+++ b/tests/test_pedigreegenotyping.py
@@ -15,6 +15,7 @@ from whatshap.core import (
 from whatshap.testhelpers import (
     string_to_readset_pedigree,
     canonic_index_list_to_biallelic_gt_list,
+    likelihoods_equal,
 )
 
 
@@ -49,7 +50,9 @@ def genotype_pedigree(
                     " expected likelihoods: ",
                     expected[individual][pos],
                 )
-                assert likelihoods == PhredGenotypeLikelihoods(expected[individual][pos])
+                assert likelihoods_equal(
+                    likelihoods, PhredGenotypeLikelihoods(expected[individual][pos])
+                ), f"Incorrect likelihoods for individual {individual} at position {pos}: got {likelihoods}, expected {PhredGenotypeLikelihoods(expected[individual][pos])}"
 
             # find the likeliest genotype
             max_val = -1
@@ -696,7 +699,7 @@ def test_weighted_genotyping():
         expected_genotypes,
         weights,
         expected,
-        scaling=500,
+        scaling=10,
     )
 
 

--- a/tests/test_run_learn.py
+++ b/tests/test_run_learn.py
@@ -18,4 +18,4 @@ def test_run_learn(tmp_path):
         window=25,
         output=observed,
     )
-    assert filecmp.cmp(expected, observed, shallow=True)
+    assert filecmp.cmp(expected, observed, shallow=False)

--- a/whatshap/testhelpers.py
+++ b/whatshap/testhelpers.py
@@ -2,9 +2,17 @@
 Utility functions only used by unit tests
 """
 
+import math
 import textwrap
 from collections import defaultdict
-from whatshap.core import Read, ReadSet, Genotype
+from whatshap.core import PhredGenotypeLikelihoods, Read, ReadSet, Genotype
+
+
+def likelihoods_equal(a: PhredGenotypeLikelihoods, b: PhredGenotypeLikelihoods):
+    for gt in a.genotypes():
+        if not math.isclose(a[gt], b[gt], abs_tol=1e-9):
+            return False
+    return True
 
 
 def string_to_readset(s, w=None, sample_ids=None, source_id=0, scale_quality=None):


### PR DESCRIPTION
This pull request focuses on stabilizing unit tests on macOS by adding robust likelihood comparisons, adjusting scaling factors to avoid numerical issues, and improving file comparison behavior.

Note: The run_learn function remains unstable, producing different results when run multiple times.