### PR TITLE
Support of multisample vcf for haplotagphase

### DIFF
--- a/tests/data/pacbio/variants_haplotagphase_multisample.vcf
+++ b/tests/data/pacbio/variants_haplotagphase_multisample.vcf
@@ -1,0 +1,21 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20160706
+##source=freeBayes v1.0.0-19-gefe685d
+##reference=reference.fasta
+##commandline="freebayes -f reference.fasta illumina-full.bam"
+##contig=<ID=ref>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Float,Description="Genotype Quality, the Phred-scaled marginal (or unconditional) probability of the called genotype">
+##FORMAT=<ID=GL,Number=G,Type=Float,Description="Genotype Likelihood, log10-scaled likelihoods of the data given the called genotype for each possible genotype generated from the reference">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=RO,Number=1,Type=Integer,Description="Reference allele observation count">
+##FORMAT=<ID=QR,Number=1,Type=Integer,Description="Sum of quality of the reference observations">
+##FORMAT=<ID=AO,Number=A,Type=Integer,Description="Alternate allele observation count">
+##FORMAT=<ID=QA,Number=A,Type=Integer,Description="Sum of quality of the alternate observations">
+##FORMAT=<ID=MIN,Number=1,Type=Integer,Description="Minimum depth in gVCF output block.">
+##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set identifier">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG004_250bp_All	Sample
+ref	10854	.	A	G	662.276	.	.	GT:PS	1|0:10854	1|0:10854
+ref	11221	.	G	A	0.0010674	.	.	GT:PS	0|1:10854	0|1:10854
+ref	11254	.	G	C	448.263	.	.	GT:PS	1|0:10854	1|0:10854

--- a/tests/test_run_haplotagphase.py
+++ b/tests/test_run_haplotagphase.py
@@ -35,8 +35,23 @@ def test_haplotagphase_multisample(tmpdir):
     tables = list(VcfReader(outvcf, phases=True, mav=True))
     for table in tables:
         print(f"{table.phases = }")
-        n_unphased = sum(1 for phase in table.phases[0] if phase is None)
-        assert n_unphased == 0
+        n_unphased = [sum(1 for phase in table.phases[x] if phase is None) for x in [0, 1]]
+        assert n_unphased == [0, 0]
+
+
+def test_haplotagphase_multisample_unphase(tmpdir):
+    outvcf = tmpdir.join("output.vcf")
+    run_haplotagphase(
+        variant_file="tests/data/pacbio/variants_haplotagphase_multisample.vcf",
+        alignment_file="tests/data/pacbio/haplotagged.bam",
+        reference="tests/data/pacbio/reference.fasta",
+        output=outvcf,
+        samples=["Sample"],
+    )
+    tables = list(VcfReader(outvcf, phases=True, mav=True))
+    for table in tables:
+        n_unphased = [sum(1 for phase in table.phases[x] if phase is None) for x in [0, 1]]
+        assert n_unphased == [0, 3]
 
 
 def test_nomav_haplototagphase(tmpdir):

--- a/tests/test_run_haplotagphase.py
+++ b/tests/test_run_haplotagphase.py
@@ -23,6 +23,22 @@ def test_haplotagphase(tmpdir):
         assert n_unphased == 4
 
 
+def test_haplotagphase_multisample(tmpdir):
+    outvcf = tmpdir.join("output.vcf")
+    run_haplotagphase(
+        variant_file="tests/data/pacbio/variants_haplotagphase_multisample.vcf",
+        alignment_file="tests/data/pacbio/haplotagged.bam",
+        reference="tests/data/pacbio/reference.fasta",
+        output=outvcf,
+        samples=["HG004_250bp_All"],
+    )
+    tables = list(VcfReader(outvcf, phases=True, mav=True))
+    for table in tables:
+        print(f"{table.phases = }")
+        n_unphased = sum(1 for phase in table.phases[0] if phase is None)
+        assert n_unphased == 0
+
+
 def test_nomav_haplototagphase(tmpdir):
     outvcf = tmpdir.join("output.vcf")
     run_haplotagphase(

--- a/tests/test_run_phase.py
+++ b/tests/test_run_phase.py
@@ -993,7 +993,7 @@ def test_with_read_merging(algorithm):
 
 def test_vcf_with_missing_headers(algorithm):
     # Since pysam 0.16, this type of invalid VCF is no longer accepted
-    with raises(CommandLineError):
+    with raises(ValueError):
         run_whatshap(
             phase_input_files=["tests/data/oneread.bam"],
             variant_file="tests/data/missing-headers.vcf",

--- a/tests/test_run_phase.py
+++ b/tests/test_run_phase.py
@@ -993,7 +993,7 @@ def test_with_read_merging(algorithm):
 
 def test_vcf_with_missing_headers(algorithm):
     # Since pysam 0.16, this type of invalid VCF is no longer accepted
-    with raises(ValueError):
+    with raises(CommandLineError):
         run_whatshap(
             phase_input_files=["tests/data/oneread.bam"],
             variant_file="tests/data/missing-headers.vcf",

--- a/tests/test_run_phase.py
+++ b/tests/test_run_phase.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from pytest import raises, fixture, mark
 import pysam
 from whatshap.cli.phase import run_whatshap
-from whatshap.cli import CommandLineError
+from whatshap.utils import CommandLineError
 from whatshap.vcf import VcfReader, VariantCallPhase
 
 

--- a/whatshap/cli/__init__.py
+++ b/whatshap/cli/__init__.py
@@ -10,15 +10,11 @@ from whatshap.bam import (
     ReferenceNotFoundError,
 )
 from whatshap.variants import ReadSetReader, ReadSetError
-from whatshap.utils import IndexedFasta, FastaNotIndexedError, detect_file_format
+from whatshap.utils import CommandLineError, IndexedFasta, FastaNotIndexedError, detect_file_format
 from whatshap.core import Genotype, ReadSet
 from whatshap.vcf import VcfReader
 
 logger = logging.getLogger(__name__)
-
-
-class CommandLineError(Exception):
-    """An anticipated command-line error occurred. This ends up as a user-visible error message"""
 
 
 def open_readset_reader(*args, **kwargs):

--- a/whatshap/cli/haplotagphase.py
+++ b/whatshap/cli/haplotagphase.py
@@ -12,10 +12,9 @@ from typing import List, Optional, Sequence, Union, Dict, Tuple
 
 from whatshap import __version__
 from whatshap.cli import PhasedInputReader, CommandLineError, log_memory_usage
-from whatshap.cli.phase import raise_if_any_sample_not_in_vcf
 from whatshap.core import NumericSampleIds, Variant, Read
 from whatshap.timer import StageTimer
-from whatshap.utils import ChromosomeFilter, IndexedFasta
+from whatshap.utils import ChromosomeFilter, IndexedFasta, raise_if_any_sample_not_in_vcf
 from whatshap.vcf import VcfReader, PhasedVcfWriter, VcfError, VcfVariant, VariantCallPhase
 
 logger = logging.getLogger(__name__)

--- a/whatshap/cli/haplotagphase.py
+++ b/whatshap/cli/haplotagphase.py
@@ -140,6 +140,7 @@ def run_haplotagphase(
                     )
                 phases = variant_table.phases_of(sample)
                 if sample not in samples:
+                    logger.info(f"Skipping sample {sample}")
                     continue
                 homozygous = dict()
                 change = dict()

--- a/whatshap/cli/haplotagphase.py
+++ b/whatshap/cli/haplotagphase.py
@@ -381,9 +381,9 @@ def compute_votes(
             if (ps, 0) not in votes[variant.position]:
                 votes[variant.position][(ps, 0)] = 0
                 votes[variant.position][(ps, 1)] = 0
-            votes[variant.position][(ps, ht ^ allele_to_id[variant.position][variant.allele])] += (
-                variant.quality
-            )
+            votes[variant.position][
+                (ps, ht ^ allele_to_id[variant.position][variant.allele])
+            ] += variant.quality
     if number_of_skipped > 0:
         logger.warning(
             f"{number_of_skipped} reads were skipped due incorrect HP. The haplotagphase command supports only a diploid input"

--- a/whatshap/cli/haplotagphase.py
+++ b/whatshap/cli/haplotagphase.py
@@ -14,8 +14,15 @@ from whatshap import __version__
 from whatshap.cli import PhasedInputReader, CommandLineError, log_memory_usage
 from whatshap.core import NumericSampleIds, Variant, Read
 from whatshap.timer import StageTimer
-from whatshap.utils import ChromosomeFilter, IndexedFasta, raise_if_any_sample_not_in_vcf
-from whatshap.vcf import VcfReader, PhasedVcfWriter, VcfError, VcfVariant, VariantCallPhase
+from whatshap.utils import ChromosomeFilter, IndexedFasta
+from whatshap.vcf import (
+    VcfReader,
+    PhasedVcfWriter,
+    VcfError,
+    VcfVariant,
+    VariantCallPhase,
+    raise_if_any_sample_not_in_vcf,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/whatshap/cli/haplotagphase.py
+++ b/whatshap/cli/haplotagphase.py
@@ -110,7 +110,7 @@ def run_haplotagphase(
                 "When using --ignore-read-groups on a VCF with "
                 "multiple samples, --sample must also be used."
             )
-        logger.info(f"{vcf_reader = }")
+
         if not samples:
             samples = vcf_reader.samples
 

--- a/whatshap/cli/phase.py
+++ b/whatshap/cli/phase.py
@@ -29,7 +29,13 @@ from typing import (
     IO,
 )
 
-from whatshap.vcf import VcfReader, PhasedVcfWriter, VcfError, VariantTable
+from whatshap.vcf import (
+    VcfReader,
+    PhasedVcfWriter,
+    VcfError,
+    VariantTable,
+    raise_if_any_sample_not_in_vcf,
+)
 from whatshap import __version__
 from whatshap.core import (
     ReadSet,
@@ -53,7 +59,7 @@ from whatshap.pedigree import (
     Trio,
 )
 from whatshap.timer import StageTimer
-from whatshap.utils import ChromosomeFilter, plural_s, raise_if_any_sample_not_in_vcf, warn_once
+from whatshap.utils import ChromosomeFilter, plural_s, warn_once
 from whatshap.cli import CommandLineError, log_memory_usage, PhasedInputReader
 from whatshap.merge import ReadMerger, DoNothingReadMerger, ReadMergerBase
 from whatshap.types import PhasingAlgorithm

--- a/whatshap/cli/phase.py
+++ b/whatshap/cli/phase.py
@@ -53,7 +53,7 @@ from whatshap.pedigree import (
     Trio,
 )
 from whatshap.timer import StageTimer
-from whatshap.utils import ChromosomeFilter, plural_s, warn_once
+from whatshap.utils import ChromosomeFilter, plural_s, raise_if_any_sample_not_in_vcf, warn_once
 from whatshap.cli import CommandLineError, log_memory_usage, PhasedInputReader
 from whatshap.merge import ReadMerger, DoNothingReadMerger, ReadMergerBase
 from whatshap.types import PhasingAlgorithm
@@ -735,13 +735,6 @@ def log_best_case_phasing_info(readset: ReadSet, selected_reads: ReadSet) -> Non
         "... would be %d non-singleton phased blocks without read selection",
         n_best_case_nonsingleton_blocks,
     )
-
-
-def raise_if_any_sample_not_in_vcf(vcf_reader: VcfReader, samples: Sequence[str]) -> None:
-    vcf_sample_set = set(vcf_reader.samples)
-    for sample in samples:
-        if sample not in vcf_sample_set:
-            raise CommandLineError(f"Sample {sample!r} requested on command-line not found in VCF")
 
 
 def setup_families(

--- a/whatshap/utils.py
+++ b/whatshap/utils.py
@@ -9,8 +9,9 @@ import sys
 import pyfaidx
 from dataclasses import dataclass
 
-from whatshap.cli import CommandLineError
-from whatshap.vcf import VcfReader
+
+class CommandLineError(Exception):
+    """An anticipated command-line error occurred. This ends up as a user-visible error message"""
 
 
 class FastaNotIndexedError(Exception):
@@ -171,7 +172,7 @@ class ChromosomeFilter:
         ) and (chromosome not in self._excluded_chromosomes)
 
 
-def raise_if_any_sample_not_in_vcf(vcf_reader: VcfReader, samples: Sequence[str]) -> None:
+def raise_if_any_sample_not_in_vcf(vcf_reader, samples: Sequence[str]) -> None:
     vcf_sample_set = set(vcf_reader.samples)
     for sample in samples:
         if sample not in vcf_sample_set:

--- a/whatshap/utils.py
+++ b/whatshap/utils.py
@@ -1,13 +1,16 @@
 from collections import defaultdict
 import gzip
 import logging
-from typing import Optional, DefaultDict, List
+from typing import Optional, DefaultDict, List, Sequence
 import os
 import stat
 import sys
 
 import pyfaidx
 from dataclasses import dataclass
+
+from whatshap.cli import CommandLineError
+from whatshap.vcf import VcfReader
 
 
 class FastaNotIndexedError(Exception):
@@ -166,3 +169,10 @@ class ChromosomeFilter:
         return (
             (not self._included_chromosomes) or (chromosome in self._included_chromosomes)
         ) and (chromosome not in self._excluded_chromosomes)
+
+
+def raise_if_any_sample_not_in_vcf(vcf_reader: VcfReader, samples: Sequence[str]) -> None:
+    vcf_sample_set = set(vcf_reader.samples)
+    for sample in samples:
+        if sample not in vcf_sample_set:
+            raise CommandLineError(f"Sample {sample!r} requested on command-line not found in VCF")

--- a/whatshap/utils.py
+++ b/whatshap/utils.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import gzip
 import logging
-from typing import Optional, DefaultDict, List, Sequence
+from typing import Optional, DefaultDict, List
 import os
 import stat
 import sys
@@ -170,10 +170,3 @@ class ChromosomeFilter:
         return (
             (not self._included_chromosomes) or (chromosome in self._included_chromosomes)
         ) and (chromosome not in self._excluded_chromosomes)
-
-
-def raise_if_any_sample_not_in_vcf(vcf_reader, samples: Sequence[str]) -> None:
-    vcf_sample_set = set(vcf_reader.samples)
-    for sample in samples:
-        if sample not in vcf_sample_set:
-            raise CommandLineError(f"Sample {sample!r} requested on command-line not found in VCF")

--- a/whatshap/vcf.py
+++ b/whatshap/vcf.py
@@ -24,7 +24,7 @@ from .core import (
     get_max_genotype_ploidy,
     get_max_genotype_alleles,
 )
-from .utils import warn_once
+from .utils import warn_once, CommandLineError
 
 logger = logging.getLogger(__name__)
 
@@ -1389,3 +1389,10 @@ class GenotypeVcfWriter(VcfAugmenter):
                 # delete all other genotype information that might have been present before
                 for tag in set(call.keys()) - GT_GL_GQ:
                     del call[tag]
+
+
+def raise_if_any_sample_not_in_vcf(vcf_reader: VcfReader, samples: Sequence[str]) -> None:
+    vcf_sample_set = set(vcf_reader.samples)
+    for sample in samples:
+        if sample not in vcf_sample_set:
+            raise CommandLineError(f"Sample {sample!r} requested on command-line not found in VCF")


### PR DESCRIPTION
The pull request introduces several changes to support working with multiple samples in the `haplotagphase` command.

- Updated the `run_haplotagphase` function to accept an optional sample parameter and handle cases where no sample is specified. If a sample is not provided, Whatshap does not modify the phasing information for the sample.