### PR TITLE
Fix distance function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ whatshap.egg-info/
 /.pytest_cache
 .eggs/
 whatshap/_version.py
+.hypothesis/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ whatshap = "whatshap.__main__:main"
 dev = [
     "Cython",
     "pytest",
+    "hypothesis",
     "sphinx>=4.4",
     "sphinx-issues",
     "pysam-stubs"

--- a/tests/test_run_phase.py
+++ b/tests/test_run_phase.py
@@ -993,7 +993,7 @@ def test_with_read_merging(algorithm):
 
 def test_vcf_with_missing_headers(algorithm):
     # Since pysam 0.16, this type of invalid VCF is no longer accepted
-    with raises(CommandLineError):
+    with raises(ValueError):
         run_whatshap(
             phase_input_files=["tests/data/oneread.bam"],
             variant_file="tests/data/missing-headers.vcf",

--- a/tests/test_run_phase.py
+++ b/tests/test_run_phase.py
@@ -993,7 +993,7 @@ def test_with_read_merging(algorithm):
 
 def test_vcf_with_missing_headers(algorithm):
     # Since pysam 0.16, this type of invalid VCF is no longer accepted
-    with raises(ValueError):
+    with raises(CommandLineError):
         run_whatshap(
             phase_input_files=["tests/data/oneread.bam"],
             variant_file="tests/data/missing-headers.vcf",

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -42,15 +42,20 @@ def reads():
     read1 = create_aligned_read("read1", 150, 250)
     read2 = create_aligned_read("read2", 300, 400)
     read3 = create_aligned_read("read3", 200, 250)
-    return read0, read1, read2, read3
+    read4 = create_aligned_read("read4", 110, 120)
+    return read0, read1, read2, read3, read4
 
 @pytest.mark.parametrize("index_a, index_b, expected_distance", [
     (0, 1, 0),
     (0, 2, 100),
     (0, 3, 0),
+    (0, 4, 0),
     (1, 2, 50),
     (1, 3, 0),
+    (1, 4, 30),
     (2, 3, 50),
+    (2, 4, 180),
+    (3, 4, 80),
 ])
 def test_distance(reads, index_a, index_b, expected_distance):
     assert reads[index_a].distance(reads[index_b]) == expected_distance

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -1,0 +1,56 @@
+import pytest
+from whatshap.variants import AlignedRead, Read
+from hypothesis import given, strategies as st
+
+def create_aligned_read(name, ref_start, ref_end):
+        return AlignedRead(
+            read=Read(name, 60, 0, 0, ref_start, "", -1, -1),
+            is_supplementary=False,
+            is_reverse=False,
+            reference_start=ref_start,
+            reference_end=ref_end,
+        )
+
+segment_strategy = st.tuples(
+    st.integers(min_value=0, max_value=2**15),
+    st.integers(min_value=0, max_value=2**15)
+).filter(lambda x: x[0] <= x[1])
+
+@given(
+    segment=segment_strategy,
+)
+def test_identity_distance(segment):
+    start, end = segment
+    read = create_aligned_read("read", start, end)
+    assert read.distance(read) == 0
+
+@given(
+    segment_a = segment_strategy,
+    segment_b = segment_strategy,
+)
+def test_pairwise_distances(segment_a, segment_b):
+    start_a, end_a = segment_a
+    start_b, end_b = segment_b
+    read_a = create_aligned_read("read_a", start_a, end_a)
+    read_b = create_aligned_read("read_b", start_b, end_b)
+    assert read_a.distance(read_b) >= 0
+    assert read_b.distance(read_a) == read_a.distance(read_b)
+
+@pytest.fixture
+def reads():
+    read0 = create_aligned_read("read0", 100, 200)
+    read1 = create_aligned_read("read1", 150, 250)
+    read2 = create_aligned_read("read2", 300, 400)
+    read3 = create_aligned_read("read3", 200, 250)
+    return read0, read1, read2, read3
+
+@pytest.mark.parametrize("index_a, index_b, expected_distance", [
+    (0, 1, 0),
+    (0, 2, 100),
+    (0, 3, 0),
+    (1, 2, 50),
+    (1, 3, 0),
+    (2, 3, 50),
+])
+def test_distance(reads, index_a, index_b, expected_distance):
+    assert reads[index_a].distance(reads[index_b]) == expected_distance

--- a/tests/test_variants.py
+++ b/tests/test_variants.py
@@ -2,19 +2,21 @@ import pytest
 from whatshap.variants import AlignedRead, Read
 from hypothesis import given, strategies as st
 
+
 def create_aligned_read(name, ref_start, ref_end):
-        return AlignedRead(
-            read=Read(name, 60, 0, 0, ref_start, "", -1, -1),
-            is_supplementary=False,
-            is_reverse=False,
-            reference_start=ref_start,
-            reference_end=ref_end,
-        )
+    return AlignedRead(
+        read=Read(name, 60, 0, 0, ref_start, "", -1, -1),
+        is_supplementary=False,
+        is_reverse=False,
+        reference_start=ref_start,
+        reference_end=ref_end,
+    )
+
 
 segment_strategy = st.tuples(
-    st.integers(min_value=0, max_value=2**15),
-    st.integers(min_value=0, max_value=2**15)
+    st.integers(min_value=0, max_value=2**15), st.integers(min_value=0, max_value=2**15)
 ).filter(lambda x: x[0] <= x[1])
+
 
 @given(
     segment=segment_strategy,
@@ -24,9 +26,10 @@ def test_identity_distance(segment):
     read = create_aligned_read("read", start, end)
     assert read.distance(read) == 0
 
+
 @given(
-    segment_a = segment_strategy,
-    segment_b = segment_strategy,
+    segment_a=segment_strategy,
+    segment_b=segment_strategy,
 )
 def test_pairwise_distances(segment_a, segment_b):
     start_a, end_a = segment_a
@@ -35,6 +38,7 @@ def test_pairwise_distances(segment_a, segment_b):
     read_b = create_aligned_read("read_b", start_b, end_b)
     assert read_a.distance(read_b) >= 0
     assert read_b.distance(read_a) == read_a.distance(read_b)
+
 
 @pytest.fixture
 def reads():
@@ -45,17 +49,21 @@ def reads():
     read4 = create_aligned_read("read4", 110, 120)
     return read0, read1, read2, read3, read4
 
-@pytest.mark.parametrize("index_a, index_b, expected_distance", [
-    (0, 1, 0),
-    (0, 2, 100),
-    (0, 3, 0),
-    (0, 4, 0),
-    (1, 2, 50),
-    (1, 3, 0),
-    (1, 4, 30),
-    (2, 3, 50),
-    (2, 4, 180),
-    (3, 4, 80),
-])
+
+@pytest.mark.parametrize(
+    "index_a, index_b, expected_distance",
+    [
+        (0, 1, 0),
+        (0, 2, 100),
+        (0, 3, 0),
+        (0, 4, 0),
+        (1, 2, 50),
+        (1, 3, 0),
+        (1, 4, 30),
+        (2, 3, 50),
+        (2, 4, 180),
+        (3, 4, 80),
+    ],
+)
 def test_distance(reads, index_a, index_b, expected_distance):
     assert reads[index_a].distance(reads[index_b]) == expected_distance

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ isolated_build = True
 usedevelop = True
 deps =
     pytest
+    hypothesis
     Cython>=0.29.17  # This can possibly be removed when tox 4 comes out
 # See pyproject.toml for pytest configuration
 commands = pytest

--- a/whatshap/variants.py
+++ b/whatshap/variants.py
@@ -74,11 +74,11 @@ class AlignedRead:
     reference_start: int
     reference_end: int
 
-    def distance(self, other) -> int:
+    def distance(self, other : "AlignedRead") -> int:
         return max(
-            other.reference_end - self.reference_start,
-            other.reference_start - self.reference_end,
             0,
+            self.reference_start - other.reference_end,
+            other.reference_start - self.reference_end,
         )
 
 

--- a/whatshap/variants.py
+++ b/whatshap/variants.py
@@ -74,7 +74,7 @@ class AlignedRead:
     reference_start: int
     reference_end: int
 
-    def distance(self, other : "AlignedRead") -> int:
+    def distance(self, other: "AlignedRead") -> int:
         return max(
             0,
             self.reference_start - other.reference_end,


### PR DESCRIPTION
- Fixed issue https://github.com/whatshap/whatshap/issues/587.
- Updated the expected exception in test_vcf_with_missing_headers - it seems vcf-parser now raises a different exception.
- Added ```hypothesis``` as a dev-dependency to enable comprehensive property-based testing.