### PR TITLE
Catch ValueError thrown by pysam 0.23 when reading a VCF without header

### DIFF
--- a/whatshap/vcf.py
+++ b/whatshap/vcf.py
@@ -922,26 +922,29 @@ def missing_headers(path: str) -> Tuple[List[str], List[str], List[str]]:
         seen_formats = set()
         seen_infos: Set[str] = set()  # INFOs encountered
 
-        for record in variant_file:
-            seen_infos.update(record.info)
-            if record.alts is not None:
-                for alt in record.alts:
-                    # If there are "vague" ALT alleles such as <INS>, <DEL> etc, then
-                    # the header needs to contain a LEN info entry even if LEN
-                    # is never used
-                    if alt.startswith("<"):
-                        seen_infos.add("END")
+        try:
+            for record in variant_file:
+                seen_infos.update(record.info)
+                if record.alts is not None:
+                    for alt in record.alts:
+                        # If there are "vague" ALT alleles such as <INS>, <DEL> etc, then
+                        # the header needs to contain a LEN info entry even if LEN
+                        # is never used
+                        if alt.startswith("<"):
+                            seen_infos.add("END")
 
-            # For the contigs, we maintain a set *and* a list because we want to
-            # keep track of the order of the contigs.
-            if record.contig not in seen_contigs:
-                contigs.append(record.contig)
-            seen_contigs.add(record.contig)
+                # For the contigs, we maintain a set *and* a list because we want to
+                # keep track of the order of the contigs.
+                if record.contig not in seen_contigs:
+                    contigs.append(record.contig)
+                seen_contigs.add(record.contig)
 
-            for fmt in record.format:
-                if fmt not in seen_formats:
-                    formats.append(fmt)
-                seen_formats.add(fmt)
+                for fmt in record.format:
+                    if fmt not in seen_formats:
+                        formats.append(fmt)
+                    seen_formats.add(fmt)
+        except ValueError as e:
+            raise VcfError(e)
 
     # Determine which contigs are missing from the header
     header_contigs = set(header.contigs)


### PR DESCRIPTION
This is to fix a failing test when using pysam 0.23 (see below), which now throws a `ValueError` when reading a VCF without header. @marcelm I wanted to give you a chance to see this before I merge it because I think you wrote [missing_headers](https://github.com/whatshap/whatshap/blob/87faeab6856431e8f7ff2c340d87943f7a2ac78a/whatshap/vcf.py#L881) and reported to pysam back then https://github.com/pysam-developers/pysam/issues/771.

```
______________________________________ test_vcf_with_missing_headers[whatshap] _______________________________________

algorithm = 'whatshap'

    def test_vcf_with_missing_headers(algorithm):
        # Since pysam 0.16, this type of invalid VCF is no longer accepted
        with raises(CommandLineError):
>           run_whatshap(
                phase_input_files=["tests/data/oneread.bam"],
                variant_file="tests/data/missing-headers.vcf",
                output="/dev/null",
                algorithm=algorithm,
            )

tests/test_run_phase.py:997: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
whatshap/cli/phase.py:402: in run_whatshap
    PhasedVcfWriter(
whatshap/vcf.py:1091: in __init__
    super().__init__(in_path, command_line, out_file, include_haploid_sets)
whatshap/vcf.py:994: in __init__
    contigs, formats, infos = missing_headers(in_path)
whatshap/vcf.py:925: in missing_headers
    for record in variant_file:
pysam/libcbcf.pyx:4195: in pysam.libcbcf.VariantFile.__next__
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   ValueError: Error(s) reading record: invalid number of columns

pysam/libcbcf.pyx:3424: ValueError
------------------------------------------------ Captured stderr call ------------------------------------------------
This is WhatsHap 2.5.dev12+g2764051f running under Python 3.10.16
[W::vcf_parse] Contig 'ref' is not defined in the header. (Quick workaround: index the file with tabix.)
[W::vcf_parse_info] INFO 'AC' is not defined in the header, assuming Type=String
[W::vcf_parse_info] INFO 'AN' is not defined in the header, assuming Type=String
[W::vcf_parse_format_dict2] FORMAT 'GT' at ref:2 is not defined in the header, assuming Type=String
[W::vcf_parse_format_dict2] FORMAT 'GL' at ref:2 is not defined in the header, assuming Type=String
[E::vcf_parse_format_empty1] FORMAT column with no sample columns starting at ref:100
------------------------------------------------- Captured log call --------------------------------------------------
INFO     whatshap.cli.phase:phase.py:358 This is WhatsHap 2.5.dev12+g2764051f running under Python 3.10.16

```

