### PR TITLE
Make help text on --ped more precise

### DIFF
--- a/whatshap/cli/genotype.py
+++ b/whatshap/cli/genotype.py
@@ -462,7 +462,7 @@ def add_arguments(parser):
     arg('--ped', metavar='PED/FAM',
         help='Use pedigree information in PED file to improve genotyping '
         '(switches to PedMEC algorithm). Columns 2, 3, 4 must refer to child, '
-        'mother, and father sample names as used in the VCF and BAM. Other '
+        'father, and mother sample names as used in the VCF and BAM. Other '
         'columns are ignored (EXPERIMENTAL).')
     arg('--recombrate', metavar='RECOMBRATE', type=float, default=1.26,
         help='Recombination rate in cM/Mb (used with --ped). If given, a constant recombination '

--- a/whatshap/cli/phase.py
+++ b/whatshap/cli/phase.py
@@ -1132,7 +1132,7 @@ def add_arguments(parser):
     arg("--ped", metavar="PED/FAM",
         help="Use pedigree information in PED file to improve phasing "
         "(switches to PedMEC algorithm). Columns 2, 3, 4 must refer to child, "
-        "mother, and father sample names as used in the VCF and BAM/CRAM. "
+        "father, and mother sample names as used in the VCF and BAM/CRAM. "
         "Other columns are ignored.")
     arg("--recombination-list", metavar="FILE", dest="recombination_list_filename", default=None,
         help="Write putative recombination events to FILE.")


### PR DESCRIPTION
The help text shown for both `genotype` and `phase` listed the mother and father column in incorrect order. Fixes Issue #588.
