### PR TITLE
Improve log message when a trio is ignored because of selected samples

### DIFF
--- a/whatshap/cli/phase.py
+++ b/whatshap/cli/phase.py
@@ -265,7 +265,8 @@ def setup_pedigree(ped_path: str, samples: Sequence[str]) -> Tuple[Sequence[Trio
             warn_once(
                 logger,
                 "Relationship %s/%s/%s ignored because at least one of the "
-                "individuals was not given by --samples.",
+                "individuals was not among the samples to be phased "
+                "(either not in the input VCF or restricted by --sample).",
                 trio.child,
                 trio.mother,
                 trio.father,


### PR DESCRIPTION
Implements a suggested improvement from Issue #557.