### PR TITLE
Fix slow wheels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 Changes
 =======
 
+v2.7 (2025-05-27)
+-----------------
+
+* Fixed build configuration, which due to changes in setuptoools, made
+  the wheels much slower (because they were compiled without optimization).
+  This only affected the wheels, not the Bioconda packages.
+
 v2.6 (2025-04-11)
 -----------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,9 @@ addopts = "--doctest-modules"
 testpaths = ["tests", "whatshap"]
 
 [tool.cibuildwheel]
-environment = "CFLAGS=-g0 CXXFLAGS=-g0"
+# Setting CFLAGS like this *disables* optimizations
+# since setuptools 75.7, see https://github.com/pypa/setuptools/issues/4836
+#environment = "CFLAGS=-g0 CXXFLAGS=-g0"
 # Disable tests for the moment because pip attempts to install pysam
 # from source for some reason although wheels exist.
 # test-requires = "pytest"


### PR DESCRIPTION
setuptools changed how they interpret CFLAGS in 75.7.0 - they’re no longer appended to the existing CFLAGS, but replace them, which means the wheels are compiled without optimization.

Thanks @rhpvorderman!

See https://github.com/marcelm/cutadapt/issues/843