### PR TITLE
Fix KeyError in whatshap compare for Beagle results

### DIFF
--- a/tests/test_run_compare.py
+++ b/tests/test_run_compare.py
@@ -3,8 +3,7 @@ Tests for 'whatshap compare'
 """
 
 from collections import namedtuple
-from whatshap.cli.compare import run_compare, compute_switch_flips_poly, compare_block
-
+from whatshap.cli.compare import run_compare, compute_switch_flips_poly, compare_block, complement
 
 def test_compare1(tmp_path):
     outtsv = tmp_path / "output.tsv"
@@ -359,3 +358,9 @@ def test_compare_mav(tmp_path):
         sample=None,
         ignore_sample_name=True,
     )
+
+def test_complement():
+    """Test that complement() handles all genotype values."""
+    assert complement("01100") == "10011"
+    assert complement("01200") == "10211"
+    assert complement("0123456789") == "1023456789"

--- a/whatshap/cli/compare.py
+++ b/whatshap/cli/compare.py
@@ -113,7 +113,7 @@ def complement(s):
     '10011'
     """
     t = {"0": "1", "1": "0"}
-    return "".join(t[c] for c in s)
+    return "".join(t.get(c, c) for c in s)
 
 
 def hamming(s0, s1):


### PR DESCRIPTION
Fixes #513 <!-- Needed for GitHub to link the issue to the PR -->

## Fix KeyError in whatshap compare for Beagle results
Fixed a `KeyError` in `whatshap compare` when processing Beagle results by making the `complement()` function handle all genotype values, not just &#39;0&#39; and &#39;1&#39;. The function now preserves any characters it doesn&#39;t recognize (like &#39;2&#39; from Beagle) instead of raising an error. Added corresponding tests to verify the fix.

The issue occurred because Beagle sometimes emits genotypes with values beyond 0/1, which caused failures in phasing comparison. This change maintains compatibility with other phasing tools while properly handling Beagle&#39;s output format.

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.ai/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1Yi5jb20vaGFycnktcGF0Y2hlci9kMTM5MTAyMWE2MzJjZjY1ODU5MDdhZDA2NjhiODQ4Zi9yYXcvc3dlYmVuY2hfd2hhdHNoYXBfX3doYXRzaGFwLTUxMy5qc29u&amp;pr=aHR0cHM6Ly9naXRodWIuY29tL3doYXRzaGFwL3doYXRzaGFwL3B1bGwvNjE2) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally [let us know](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu&r1e8e3930f96f400aa91b5105dbd09b7d=https%3A//github.com/whatshap/whatshap/pull/616&rb85bea8de07843f9835f9d001f689f4c=https%3A//github.com/whatshap/whatshap&r034de175aef248b29aaf36f2a5e92912=https%3A//github.com/whatshap/whatshap/pull/616&r9e0cc5d7ff8b484e81eb97531d4cefd7=https%3A//github.com/whatshap/whatshap/pull/616) 📬.